### PR TITLE
Course models

### DIFF
--- a/packages/models/src/assignment-chat.ts
+++ b/packages/models/src/assignment-chat.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+
+export const AssignmentUploadedFileSchema = z.object({
+    url: z.instanceof(File).or(z.string()),
+    name: z.string(),
+    size: z.number(),  // in bytes
+})
+
+export type TAssignmentUploadedFile = z.infer<typeof AssignmentUploadedFileSchema>
+
+export const AssignmentLinksSchema = z.object({
+    link: z.string(),
+    title: z.string(),
+    image: z.instanceof(File).or(z.string()),
+})
+
+export type TAssignmentLinks = z.infer<typeof AssignmentLinksSchema>
+
+
+export const AssignmentMessageSchema = z.object({
+    timedate: z.string().datetime(),
+    message: z.string(),
+    description: z.string(),
+    links: z.array(AssignmentLinksSchema).default([]),
+    files: z.array(AssignmentUploadedFileSchema).default([]),
+})
+
+export type TAssignmentMessage = z.infer<typeof AssignmentMessageSchema>
+
+export const AssignmentChatSchema = z.object({
+    isStudent: z.boolean(),
+    message: AssignmentMessageSchema,
+})
+
+/**
+ * Schema for an Assignment Chat
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+export type TAssignmentChat = z.infer<typeof AssignmentChatSchema>

--- a/packages/models/src/category.ts
+++ b/packages/models/src/category.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+
+export const CategorySchema = z.object({
+    title: z.string(),
+})
+
+/**
+ * Schema for a category.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TCategory = z.infer<typeof CategorySchema>

--- a/packages/models/src/course-review.ts
+++ b/packages/models/src/course-review.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+export const CourseReviewSchema = z.object({
+
+})
+
+/**
+ * Schema for a course review.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TCourseReview = z.infer<typeof CourseReviewSchema>

--- a/packages/models/src/course.ts
+++ b/packages/models/src/course.ts
@@ -30,4 +30,4 @@ export const CourseMetadataSchema = z.object({
  * - `duration`: A number indicating the duration of the course.
  */
 
-export type TCourseMetedata = z.infer<typeof CourseMetadataSchema>
+export type TCourseMetadata = z.infer<typeof CourseMetadataSchema>

--- a/packages/models/src/course.ts
+++ b/packages/models/src/course.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const CourseMetedataSchema = z.object({
+export const CourseMetadataSchema = z.object({
     title: z.string(),
     description: z.string(),
     duration: z.number(),
@@ -18,4 +18,4 @@ export const CourseMetedataSchema = z.object({
  * - `duration`: A number indicating the duration of the course.
  */
 
-export type TCourseMetedata = z.infer<typeof CourseMetedataSchema>
+export type TCourseMetedata = z.infer<typeof CourseMetadataSchema>

--- a/packages/models/src/course.ts
+++ b/packages/models/src/course.ts
@@ -1,9 +1,21 @@
 import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+export const CourseDurationSchema = z.object({
+    video: z.number(),  // in minutes, duration of video content
+    coaching: z.number(),  // in minutes, duration of coaching sessions
+    selfStudy: z.number(),  // in minutes, duration of self-study content
+})
 
 export const CourseMetadataSchema = z.object({
     title: z.string(),
     description: z.string(),
-    duration: z.number(),
+    duration: CourseDurationSchema,
+    image: z.string(),
+    rating: z.number(),
+    author: z.string(),
+    authorImage: z.string(),
+    language: LanguageSchema,
 })
 
 /**

--- a/packages/models/src/lesson-component.ts
+++ b/packages/models/src/lesson-component.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+
+export const LessonComponentSchema = z.object({
+})
+
+/**
+ * Schema for a lesson component.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TLessonComponent = z.infer<typeof LessonComponentSchema>

--- a/packages/models/src/lesson.ts
+++ b/packages/models/src/lesson.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+
+export const LessonSchema = z.object({
+    title: z.string(),
+})
+
+/**
+ * Schema for a lesson.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TLesson = z.infer<typeof LessonSchema>

--- a/packages/models/src/milestone.ts
+++ b/packages/models/src/milestone.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+
+export const MilestoneSchema = z.object({
+    title: z.string(),
+})
+
+/**
+ * Schema for a milestone.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TMilestone = z.infer<typeof MilestoneSchema>

--- a/packages/models/src/module.ts
+++ b/packages/models/src/module.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+
+export const ModuleSchema = z.object({
+    title: z.string(),
+})
+
+/**
+ * Schema for a module.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ * - `title`: A string representing the title of the course.
+ * - `description`: A string providing a brief description of the course.
+ * - `duration`: A number indicating the duration of the course.
+ */
+
+export type TModule = z.infer<typeof ModuleSchema>

--- a/packages/models/src/package.ts
+++ b/packages/models/src/package.ts
@@ -1,8 +1,25 @@
 import { z } from 'zod'
-import { LanguageSchema } from './language'
+
+export const PackageDurationSchema = z.object({
+    hours: z.number(),
+    minutes: z.number(),
+})
+export type TPackageDuration = z.infer<typeof PackageDurationSchema>
+
+export const PackagePricingSchema = z.object({
+    fullPrice: z.number(),
+    partialPrice: z.number(),
+    currency: z.string(),
+})
+export type TPackagePricing = z.infer<typeof PackagePricingSchema>
+
 
 export const PackageSchema = z.object({
-
+    title: z.string(),
+    imageUrl: z.string(),
+    duration: PackageDurationSchema,
+    description: z.string(),
+    pricing: PackagePricingSchema,
 })
 
 /**

--- a/packages/models/src/package.ts
+++ b/packages/models/src/package.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { LanguageSchema } from './language'
+
+export const PackageSchema = z.object({
+
+})
+
+/**
+ * Schema for a package
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TPackage = z.infer<typeof PackageSchema>

--- a/packages/models/src/profile.ts
+++ b/packages/models/src/profile.ts
@@ -2,9 +2,18 @@ import { z } from "zod";
 import { LanguageSchema } from "./language";
 
 
+export const UserAvatarSchema = z.object({
+    initials: z.string(),
+    imageUrl: z.string(),
+    size: z.enum(['xSmall', 'small', 'medium', 'large', 'xLarge']).optional(),
+});
+export type TUserAvatar = z.infer<typeof UserAvatarSchema>;
+
+
 export const BasePersonalProfileSchema = z.object({
     name: z.string().min(1, "Name is required"),
     surname: z.string().min(1, "Surname is required"),
+    avatar: UserAvatarSchema,
     email: z.string().email("Invalid email address"),
     phoneNumber: z.string().optional(),
     dateOfBirth: z.string().date().optional(),  // YYYY-MM-DD

--- a/packages/models/src/topic.ts
+++ b/packages/models/src/topic.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+
+export const TopicSchema = z.object({
+    title: z.string(),
+})
+
+/**
+ * Schema for a topic.
+ * 
+ * This schema validates the structure of course metadata objects, ensuring they contain
+ * the required properties with the correct types.
+ * 
+ * Properties:
+ */
+
+export type TTopic = z.infer<typeof TopicSchema>

--- a/packages/models/tests/course.test.ts
+++ b/packages/models/tests/course.test.ts
@@ -1,4 +1,4 @@
-import { CourseMetedataSchema, TCourseMetedata } from '../src/course';
+import { CourseMetadataSchema, TCourseMetedata } from '../src/course';
 import { describe, it, expect } from 'vitest';
 
 describe('course', () => {
@@ -8,6 +8,6 @@ describe('course', () => {
             description: 'A beginner-friendly introduction to TypeScript.',
             duration: 60,
         };
-        expect(CourseMetedataSchema.safeParse(validCourse).success).toBe(true);
+        expect(CourseMetadataSchema.safeParse(validCourse).success).toBe(true);
     });
 });

--- a/packages/models/tests/course.test.ts
+++ b/packages/models/tests/course.test.ts
@@ -1,9 +1,9 @@
-import { CourseMetadataSchema, TCourseMetedata } from '../src/course';
+import { CourseMetadataSchema, TCourseMetadata } from '../src/course';
 import { describe, it, expect } from 'vitest';
 
 describe('course', () => {
     it('should validate course metadata', () => {
-        const validCourse: TCourseMetedata = {
+        const validCourse: TCourseMetadata = {
             title: 'Introduction to TypeScript',
             description: 'A beginner-friendly introduction to TypeScript.',
             duration: 60,


### PR DESCRIPTION
All models related to courses, fix #18.

Will implement this part of the backend diagram, where the yellow links are to represent different types of an entity:

![immagine](https://github.com/user-attachments/assets/e71cba3e-387c-4d43-bc44-ae04df393e57)
