### PR TITLE
chore(reset): Reset workspace dependencies post 1.5.0 release

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,7 +15,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "zod": "^3.24.1",
-    "@maany_shr/e-class-models": "1.5.0"
+    "@maany_shr/e-class-models": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -17,8 +17,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@maany_shr/e-class-models": "1.5.0",
-    "@maany_shr/e-class-translations": "1.5.0",
+    "@maany_shr/e-class-models": "workspace:*",
+    "@maany_shr/e-class-translations": "workspace:*",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "16.1.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
This pull request includes changes to the `package.json` files in the `auth` and `ui-kit` packages to update dependencies to use workspace references. This ensures that the dependencies are resolved from the local workspace, which can help with consistent versioning and easier development.

Dependency updates:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL18-R18): Updated the `@maany_shr/e-class-models` dependency to use `workspace:*`.
* [`packages/ui-kit/package.json`](diffhunk://#diff-ce27719201b90b4051b5369de9b51a0abfb4cf782cfeb188891682057222ea1cL20-R21): Updated the `@maany_shr/e-class-models` and `@maany_shr/e-class-translations` dependencies to use `workspace:*`.