### PR TITLE
chore: change dependencies to 'workspace:*' for local development

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "zod": "^3.24.1",
     "next-auth": "5.0.0-beta.25",
-    "@maany_shr/e-class-models": "1.6.1"
+    "@maany_shr/e-class-models": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -17,8 +17,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@maany_shr/e-class-models": "1.6.1",
-    "@maany_shr/e-class-translations": "1.6.1",
+    "@maany_shr/e-class-models": "workspace:*",
+    "@maany_shr/e-class-translations": "workspace:*",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "16.1.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
This PR changes dependencies to 'workspace:*' for local development, from v1.6.1