### PR TITLE
[TSK-836] Update CI command to use run-many for tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
       # When you enable task distribution, run the e2e-ci task instead of e2e
       - name: Run lint, test, build, and e2e
-        run: pnpm exec nx affected --no-cloud -t lint test build e2e
+        run: pnpm exec nx run-many --no-cloud -t lint test build e2e
         env:
           'AUTH_SECRET': 'Wu/hegOKb+gqUY9pBZeLyZQLatMlZSWvK'
           'AUTH_ENABLE_TEST_ACCOUNTS': 'true'


### PR DESCRIPTION
Replace the command for running lint, test, build, and e2e tasks in the CI configuration to utilize `run-many` for improved efficiency.