### PR TITLE
feat(dropdown): add position prop for customizable dropdown placement

### DIFF
--- a/packages/ui-kit/lib/components/dropdown.tsx
+++ b/packages/ui-kit/lib/components/dropdown.tsx
@@ -6,18 +6,20 @@ import { IconChevronUp } from './icons/icon-chevron-up';
 import { IconChevronDown } from './icons/icon-chevron-down';
 import { InputField } from './input-field';
 import { IconSearch } from './icons/icon-search';
+import { cn } from '../utils/style-utils';
 
 export interface DropdownProps {
   type: 'simple' | 'choose-color' | 'multiple-choice-and-search';
   options: { label: React.ReactNode; value: string }[];
   onSelectionChange: (selected: string | string[] | null) => void;
   className?: string;
-  defaultValue?: string | string[]; // New optional prop
+  defaultValue?: string | string[];
   text: {
     simpleText?: string;
     colorText?: string;
     multiText?: string;
   };
+  position?: 'top' | 'bottom';
 }
 
 /**
@@ -62,6 +64,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   className,
   defaultValue,
   text,
+  position = 'bottom',
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -156,7 +159,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
 
       {/* Dropdown Content */}
       {isOpen && (
-        <div className="mt-2 z-50 absolute w-auto">
+        <div className={cn(" z-50 absolute w-auto", position === 'bottom' ? 'mt-2' : 'bottom-12')}>
           {' '}
           {/* Ensure absolute positioning and higher z-index */}
           {/* Simple Dropdown */}

--- a/packages/ui-kit/stories/dropdown.stories.tsx
+++ b/packages/ui-kit/stories/dropdown.stories.tsx
@@ -20,6 +20,16 @@ const meta: Meta<typeof Dropdown> = {
     defaultValue: { control: 'text' },
     className: { control: 'text' },
     onSelectionChange: { action: 'selectionChanged' },
+    text: {
+      control: 'object',
+      description: 'Placeholder texts for different dropdown types',
+    },
+    position: {
+      control: {
+        type: 'select',
+        options: ['top', 'bottom'],
+      },
+    },
   },
 };
 
@@ -112,22 +122,22 @@ const multiSelectOptions = [
 ];
 
 const StatefulDropdown = (args: DropdownProps) => {
-  const [selectedValue, setSelectedValue] = useState<
-    string | string[] | undefined
-  >(
-    args.defaultValue || undefined, // Initialize with undefined instead of null
+  const [selectedValue, setSelectedValue] = useState<string | string[] | null>(
+    args.defaultValue || null,
   );
 
   const handleSelectionChange = (value: string | string[] | null) => {
-    setSelectedValue(value ?? undefined); // Convert null to undefined
-    args.onSelectionChange(value); // Trigger the action for logging in Storybook
+    setSelectedValue(value);
+    args.onSelectionChange(value);
   };
 
   return (
     <Dropdown
       {...args}
-      defaultValue={selectedValue}
+      defaultValue={args.defaultValue}
       onSelectionChange={handleSelectionChange}
+      text={args.text}
+      position={args.position}
     />
   );
 };
@@ -138,7 +148,11 @@ export const SimpleDropdown: Story = {
     type: 'simple',
     options: simpleOptions,
     defaultValue: simpleOptions[0].value,
-    className: '',
+    className: 'w-64',
+    text: {
+      simpleText: 'Select an option',
+    },
+    position: 'bottom',
   },
 };
 
@@ -148,7 +162,11 @@ export const ChooseColorDropdown: Story = {
     type: 'choose-color',
     options: colorOptions,
     defaultValue: colorOptions[0].value,
-    className: '',
+    className: 'w-64',
+    text: {
+      colorText: 'Choose a color',
+    },
+    position: 'bottom',
   },
 };
 
@@ -158,9 +176,10 @@ export const MultiSelectAndSearchDropdown: Story = {
     type: 'multiple-choice-and-search',
     options: multiSelectOptions,
     defaultValue: [multiSelectOptions[0].value, multiSelectOptions[2].value],
-    className: '',
+    className: 'w-64',
     text: {
       multiText: 'Choose Options',
     },
+    position: 'bottom',
   },
 };

--- a/packages/ui-kit/stories/dropdown.stories.tsx
+++ b/packages/ui-kit/stories/dropdown.stories.tsx
@@ -174,7 +174,24 @@ export const MultiSelectAndSearchDropdown: Story = {
   render: (args) => <StatefulDropdown {...args} />,
   args: {
     type: 'multiple-choice-and-search',
-    options: multiSelectOptions,
+    options: [
+      {
+        label: 'Checkbox Alpha',
+        value: 'Checkbox Alpha',
+      },
+      {
+        label: 'Checkbox Beta BetaBetaBetaBetaBetaBeta',
+        value: 'Checkbox Beta',
+      },
+      {
+        label: 'Checkbox Gamma',
+        value: 'Checkbox Gamma',
+      },
+      {
+        label: 'Checkbox Delta',
+        value: 'Checkbox Delta',
+      },
+    ],
     defaultValue: [multiSelectOptions[0].value, multiSelectOptions[2].value],
     className: 'w-64',
     text: {


### PR DESCRIPTION
The footer dropdown was opening `downward` instead of upward as intended, so the Dropdown component has been updated to correctly handle the `position='top'` prop by applying `bottom-full mb-2 ` classes, while preserving the default `position='bottom' ` behavior for other uses like the NavBar.