### PR TITLE
feat(input-field): add inputClassName prop for custom input styling

### DIFF
--- a/packages/ui-kit/lib/components/buy-coaching-session.tsx
+++ b/packages/ui-kit/lib/components/buy-coaching-session.tsx
@@ -110,7 +110,8 @@ function BuyCoachingSession({ courses, onClick, locale,currencyType }: BuyCoachi
                             </button>
                             <InputField
                                 type='number'
-                                className='w-[3rem] h-[3rem] text-lg text-center'
+                                className='w-[3rem] h-[3rem] text-lg'
+                                inputClassName='text-center'
                                 value={course.totalSessions.toString()}
                                 setValue={(value) => handleInputChange(course.id, value)}
                             />

--- a/packages/ui-kit/lib/components/input-field.tsx
+++ b/packages/ui-kit/lib/components/input-field.tsx
@@ -19,6 +19,7 @@ export interface InputFieldProps {
   type?: 'text' | 'password'|'number';
   id?: string;
   className?: string;
+  inputClassName?: string;
 }
 
 /**
@@ -40,7 +41,9 @@ export interface InputFieldProps {
  * @param setValue Callback function triggered when the value changes. Receives the new value as a string.
  * @param type The type of input. Options: `text` (default) or `password`.
  * @param id Optional unique ID for identifying this specific input field (useful for testing or accessibility).
- *
+ * @param className Optional additional CSS classes to apply to the outer container.
+ * @param inputClassName Optional additional CSS classes to apply to the input element.
+ * 
  * @example
  * <InputField
  *   hasLeftContent={true}
@@ -65,7 +68,8 @@ export const InputField: FC<InputFieldProps> = ({
   setValue,
   type = 'text',
   id,
-  className
+  className,
+  inputClassName
 }) => {
   const [borderColor, setBorderColor] = useState(false);
 
@@ -96,7 +100,7 @@ export const InputField: FC<InputFieldProps> = ({
           onChange={(e) => setValue(e.target.value)}
           onFocus={() => setBorderColor(true)}
           onBlur={() => setBorderColor(false)}
-          className="bg-transparent outline-none [-moz-appearance:textfield] flex-1 placeholder-text-secondary h-full w-full appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none text-center"
+          className={cn("bg-transparent outline-none [-moz-appearance:textfield] flex-1 placeholder-text-secondary h-full w-full appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",inputClassName)}
         />
         {hasRightContent && rightContent}
       </div>

--- a/packages/ui-kit/lib/components/profile/professional-info.tsx
+++ b/packages/ui-kit/lib/components/profile/professional-info.tsx
@@ -157,6 +157,7 @@ export const ProfessionalInfo: React.FC<ProfessionalInfoProps> = ({
           <TextInput
             label={dictionary.components.professionalInfo.linkedinUrl}
             inputField={{
+              className:"w-full",
               value: formData.linkedinUrl ? formData.linkedinUrl : '',
               setValue: (value) => handleChange('linkedinUrl', value),
               inputText:
@@ -184,6 +185,7 @@ export const ProfessionalInfo: React.FC<ProfessionalInfoProps> = ({
             inputField={{
               value: formData.portfolioWebsite ? formData.portfolioWebsite : '',
               setValue: (value) => handleChange('portfolioWebsite', value),
+              className:"w-full",
               inputText:
                 dictionary.components.professionalInfo
                   .portfolioWebsitePlaceholder,
@@ -199,6 +201,7 @@ export const ProfessionalInfo: React.FC<ProfessionalInfoProps> = ({
                 ? formData.associatedCompanyName
                 : '',
               setValue: (value) => handleChange('associatedCompanyName', value),
+              className:"w-full",
               inputText:
                 dictionary.components.professionalInfo
                   .associatedCompanyPlaceholder,
@@ -214,6 +217,7 @@ export const ProfessionalInfo: React.FC<ProfessionalInfoProps> = ({
                 ? formData.associatedCompanyRole
                 : '',
               setValue: (value) => handleChange('associatedCompanyRole', value),
+              className:"w-full",
               inputText:
                 dictionary.components.professionalInfo
                   .associatedCompanyIndustryPlaceholder,
@@ -232,6 +236,7 @@ export const ProfessionalInfo: React.FC<ProfessionalInfoProps> = ({
                 : '',
               setValue: (value) =>
                 handleChange('associatedCompanyIndustry', value),
+              className:"w-full",
               inputText:
                 dictionary.components.professionalInfo
                   .associatedCompanyPlaceholder,

--- a/packages/ui-kit/lib/components/profile/profile-info.tsx
+++ b/packages/ui-kit/lib/components/profile/profile-info.tsx
@@ -128,9 +128,11 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({
           {dictionary.components.profileInfo.title}
         </h1>
         <TextInput
+        
           label={dictionary.components.profileInfo.name}
           inputField={{
             id: 'name',
+            className:"w-full",
             value: formData.name,
             setValue: (value) => handleChange('name', value),
             inputText: dictionary.components.profileInfo.namePlaceholder,
@@ -140,6 +142,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({
           label={dictionary.components.profileInfo.surname}
           inputField={{
             id: 'surname',
+            className:"w-full",
             value: formData.surname,
             setValue: (value) => handleChange('surname', value),
             inputText: dictionary.components.profileInfo.surnamePlaceholder,
@@ -149,6 +152,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({
           label={dictionary.components.profileInfo.email}
           inputField={{
             id: 'email',
+            className:"w-full",
             value: formData.email,
             setValue: (value) => handleChange('email', value),
             inputText: dictionary.components.profileInfo.emailPlaceholder,
@@ -158,6 +162,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({
           label={dictionary.components.profileInfo.phoneNumber}
           inputField={{
             id: 'phone',
+            className:"w-full",
             value: formData.phoneNumber || '',
             setValue: (value) => handleChange('phoneNumber', value),
             inputText: dictionary.components.profileInfo.phoneNumberPlaceholder,
@@ -167,6 +172,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({
           label={dictionary.components.profileInfo.password}
           inputField={{
             id: 'password',
+            className:"w-full",
             value: formData.phoneNumber || '',
             setValue: (value) => handleChange('phoneNumber', value),
             inputText: dictionary.components.profileInfo.password,


### PR DESCRIPTION
Added ` inputClassName `prop to TextField component to allow input customization and also done changes in component where we have used the text field component.


fix #132