### PR TITLE
[TSK-866] Add exceptions to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,32 @@
 # Editor configuration, see http://editorconfig.org
 root = true
 
+# Default settings for all files
 [*]
 charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+# Python files
+[*.{py,pyi}]
+indent_size = 4
+
+# TypeScript/JavaScript files
+[*.{ts,tsx,js,jsx,json,mjs}]
+indent_size = 4
+
+# Markdown files
 [*.md]
 max_line_length = off
-trim_trailing_whitespace = false
+trim_trailing_whitespace = false  # Trailing whitespace is significant in Markdown
+
+[{.git/**,node_modules/**,venv/**,__pycache__/**,dist/**,build/**}]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+trim_trailing_whitespace = unset
+insert_final_newline = unset


### PR DESCRIPTION
This PR adds differing rules for some file formats in .editorconfig. This will facilitate the development process by setting a correct indent for Python or TypeScript files.