### PR TITLE
[TSK-920] Include base-brand color in @theme block

### DIFF
--- a/packages/ui-kit/lib/assets/css/tailwind.css
+++ b/packages/ui-kit/lib/assets/css/tailwind.css
@@ -60,6 +60,17 @@
   --color-base-neutral-800: var(--color-base-neutral-800);
   --color-base-neutral-900: var(--color-base-neutral-900);
   --color-base-neutral-950: var(--color-base-neutral-950);
+  --color-base-brand-50: var(--color-base-brand-50);
+  --color-base-brand-100: var(--color-base-brand-100);
+  --color-base-brand-200: var(--color-base-brand-200);
+  --color-base-brand-300: var(--color-base-brand-300);
+  --color-base-brand-400: var(--color-base-brand-400);
+  --color-base-brand-500: var(--color-base-brand-500);
+  --color-base-brand-600: var(--color-base-brand-600);
+  --color-base-brand-700: var(--color-base-brand-700);
+  --color-base-brand-800: var(--color-base-brand-800);
+  --color-base-brand-900: var(--color-base-brand-900);
+  --color-base-brand-950: var(--color-base-brand-950);
   --color-action-brand-50: var(--color-base-brand-50);
   --color-action-brand-100: var(--color-base-brand-100);
   --color-action-brand-200: var(--color-base-brand-200);


### PR DESCRIPTION
This PR ensures the brand palette can be used in components without defining intermediate variables. This might be useful for preparing quick demo components in the future.

The data-theme attribute approach doesn't have any benefits apart from being a convention. As this change will require resolving conflicts with some ongoing work, it seems better to leave it as is.

Edit by LB: Fix #142