### PR TITLE
chore: change dependencies to 'workspace:*' for local development

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@maany_shr/e-class-auth",
-    "version": "1.14.0",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.mjs",
-            "default": "./dist/index.js"
-        }
-    },
-    "dependencies": {
-        "zod": "^3.24.1",
-        "next-auth": "5.0.0-beta.25",
-        "@maany_shr/e-class-models": "1.14.0"
-    },
-    "publishConfig": {
-        "access": "public"
+  "name": "@maany_shr/e-class-auth",
+  "version": "1.14.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
     }
+  },
+  "dependencies": {
+    "zod": "^3.24.1",
+    "next-auth": "5.0.0-beta.25",
+    "@maany_shr/e-class-models": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "@maany_shr/e-class-ui-kit",
-    "version": "1.14.0",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.js"
-        },
-        "./css/tailwind.css": {
-            "import": "./css/tailwind.js"
-        },
-        "./package.json": "./package.json"
+  "name": "@maany_shr/e-class-ui-kit",
+  "version": "1.14.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
-    "dependencies": {
-        "@maany_shr/e-class-models": "1.14.0",
-        "@maany_shr/e-class-translations": "1.14.0",
-        "@mux/mux-player-react": "^3.3.0",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "16.1.0",
-        "ag-grid-community": "^33.2.4",
-        "ag-grid-react": "^33.2.4",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "lucide-react": "^0.473.0",
-        "react": "19.0.0",
-        "react-dropzone": "^14.3.5",
-        "slate": "^0.112.0",
-        "slate-history": "^0.110.3",
-        "slate-react": "^0.112.1",
-        "tailwind-merge": "^2.5.5",
-        "vitest": "^2.1.8",
-        "zod": "^3.24.1"
+    "./css/tailwind.css": {
+      "import": "./css/tailwind.js"
     },
-    "publishConfig": {
-        "access": "public"
-    }
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@maany_shr/e-class-models": "workspace:*",
+    "@maany_shr/e-class-translations": "workspace:*",
+    "@mux/mux-player-react": "^3.3.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "16.1.0",
+    "ag-grid-community": "^33.2.4",
+    "ag-grid-react": "^33.2.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.473.0",
+    "react": "19.0.0",
+    "react-dropzone": "^14.3.5",
+    "slate": "^0.112.0",
+    "slate-history": "^0.110.3",
+    "slate-react": "^0.112.1",
+    "tailwind-merge": "^2.5.5",
+    "vitest": "^2.1.8",
+    "zod": "^3.24.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
This PR changes dependencies to 'workspace:*' for local development, from v1.14.0