### PR TITLE
[TSK-1036] Add onDeserializationError callback to rich text components

### DIFF
--- a/packages/ui-kit/lib/components/course-builder-lesson-component/types.ts
+++ b/packages/ui-kit/lib/components/course-builder-lesson-component/types.ts
@@ -9,6 +9,7 @@ export interface LessonNoteBuilderViewType extends isLocalAware {
     onChange: (value: string) => boolean;
     children?: React.ReactNode;
     placeholder: string;
+    onDeserializationError: (message: string, error: Error) => void;
 };
 
 export interface LessonNoteStudentViewType extends isLocalAware {

--- a/packages/ui-kit/lib/components/course-builder/course-builder-core.ts
+++ b/packages/ui-kit/lib/components/course-builder/course-builder-core.ts
@@ -1,10 +1,10 @@
-import { CourseElementRegistry } from "./types";
+//import { CourseElementRegistry } from "./types";
 
 
 /**
  * Collection of all available form elements
  * @public
  */
-export const courseElements: CourseElementRegistry = {
-
-};
+//export const courseElements: CourseElementRegistry = {
+// TODO: fill this properly, otherwise typechecking will fail
+//};

--- a/packages/ui-kit/lib/components/lesson-components/rich-text.tsx
+++ b/packages/ui-kit/lib/components/lesson-components/rich-text.tsx
@@ -54,7 +54,12 @@ const richTextElement: FormElementTemplate = {
 function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, onDeleteClick }: DesignerComponentProps) {
     if (elementInstance.type !== FormElementType.RichText) return null;
     const dictionary = getDictionary(locale);
-    const [content, setContent] = useState<Descendant[]>(deserialize(elementInstance.content || ""));
+
+    const onDeserializationError = (message: string, error: Error) => {
+        // TODO: see how to pass a callback from the parent to here
+    }
+
+    const [content, setContent] = useState<Descendant[]>(deserialize({ serializedData: elementInstance.content || "", onError: onDeserializationError }));
 
     const handleContentChange = (value: Descendant[]) => {
         setContent(value);
@@ -83,6 +88,7 @@ function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, on
                 onLoseFocus={handleLoseFocus}
                 placeholder={dictionary.components.formRenderer.pleaseEnterText}
                 locale={locale}
+                onDeserializationError={onDeserializationError}
             />
         </DesignerLayout>
     );
@@ -97,9 +103,13 @@ function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, on
 export function FormComponent({ elementInstance }: { elementInstance: FormElement }) {
     if (elementInstance.type !== FormElementType.RichText) return null;
 
+    const onDeserializationError = (message: string, error: Error) => {
+        // TODO: see how to pass a callback from the parent to here
+    }
+
     return (
         <div className="text-text-primary flex flex-col gap-2">
-            <RichTextRenderer content={elementInstance.content} />
+            <RichTextRenderer content={elementInstance.content} onDeserializationError={onDeserializationError} />
         </div>
     );
 }
@@ -111,9 +121,13 @@ export function FormComponent({ elementInstance }: { elementInstance: FormElemen
 function ViewComponent({ elementInstance }: { elementInstance: FormElement }) {
     if (elementInstance.type !== FormElementType.RichText) return null;
 
+    const onDeserializationError = (message: string, error: Error) => {
+        // TODO: see how to pass a callback from the parent to here
+    }
+
     return (
         <div className="text-text-primary flex flex-col">
-            <RichTextRenderer content={elementInstance.content} />
+            <RichTextRenderer content={elementInstance.content} onDeserializationError={onDeserializationError} />
         </div>
     );
 }

--- a/packages/ui-kit/lib/components/lesson-components/text-input.tsx
+++ b/packages/ui-kit/lib/components/lesson-components/text-input.tsx
@@ -66,17 +66,23 @@ const textInputElement: FormElementTemplate = {
 function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, onDeleteClick }: DesignerComponentProps) {
   if (elementInstance.type !== FormElementType.TextInput) return null;
   const dictionary = getDictionary(locale);
-  const [helperText, setHelperText] = useState<Descendant[]>(deserialize(elementInstance.helperText));
+
+  const onDeserializationError = (message: string, error: Error) => {
+    // TODO: see how to pass a callback from the parent component to here
+  };
+
+  const [helperText, setHelperText] = useState<Descendant[]>(deserialize({ serializedData: elementInstance.helperText, onError: onDeserializationError }
+  ));
   const [isRequired, setIsRequired] = useState<boolean>(elementInstance.required || false);
 
   const handleContentChange = (value: Descendant[]) => {
     const contentString = serialize(value);
     setHelperText(value);
-
+    // TODO: Update the content in the element instance
   };
 
   const handleLoseFocus = (value: string) => {
-    // Update the element instance with the new content
+    // TODO: Update the element instance with the new content
   };
 
   const handleRequiredChange = () => {
@@ -105,6 +111,7 @@ function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, on
           onLoseFocus={handleLoseFocus}
           placeholder={dictionary.components.formRenderer.pleaseEnterText}
           locale={locale}
+          onDeserializationError={onDeserializationError}
         />
       </section>
     </DesignerLayout>
@@ -122,7 +129,14 @@ function DesignerComponent({ elementInstance, locale, onUpClick, onDownClick, on
  */
 export function FormComponent({ elementInstance, submitValue, locale }: FormComponentProps) {
   if (elementInstance.type !== FormElementType.TextInput) return null;
-  const [value, setValue] = useState<Descendant[]>(deserialize(""));
+
+  const onDeserializationError = (message: string, error: Error) => {
+    // TODO: see how to pass a callback from the parent component to here
+  }
+
+  const [value, setValue] = useState<Descendant[]>(deserialize(
+    { serializedData: "", onError: onDeserializationError }));
+
   const dictionary = getDictionary(locale);
 
   const onLoseFocus = () => {
@@ -138,7 +152,7 @@ export function FormComponent({ elementInstance, submitValue, locale }: FormComp
   return (
     <div className="text-text-primary flex flex-col gap-2 w-full">
       <section className="text-sm flex leading-[21px]">
-        <TextInputRenderer content={elementInstance.helperText} />
+        <TextInputRenderer content={elementInstance.helperText} onDeserializationError={onDeserializationError} />
         {elementInstance.required && <span className="text-feedback-error-primary ml-1">*</span>}
       </section>
       <section className="w-full">
@@ -149,6 +163,7 @@ export function FormComponent({ elementInstance, submitValue, locale }: FormComp
           initialValue={value}
           onChange={(value) => setValue(value)} // TODO: This is a no-op that will be replaced with a real function when we implement the builder
           onLoseFocus={onLoseFocus}
+          onDeserializationError={onDeserializationError}
         />
       </section>
     </div>
@@ -165,15 +180,20 @@ export function FormComponent({ elementInstance, submitValue, locale }: FormComp
 function ViewComponent({ elementInstance }: { elementInstance: FormElement }) {
   if (elementInstance.type !== FormElementType.TextInput) return null;
 
+  const onDeserializationError = (message: string, error: Error) => {
+    // TODO: see how to pass a callback from the parent component to here
+  }
+
   return (
     <div className="text-text-primary flex flex-col gap-4">
       <section className="text-sm leading-[21px] text-text-secondary">
-        <TextInputRenderer content={elementInstance.helperText} />
+        <TextInputRenderer content={elementInstance.helperText} onDeserializationError={onDeserializationError} />
       </section>
       {"content" in elementInstance && (
         <TextInputRenderer
           className="p-2 bg-base-neutral-800 rounded-md"
           content={elementInstance.content}
+          onDeserializationError={onDeserializationError}
         />
       )}
     </div>

--- a/packages/ui-kit/lib/components/lesson-note/lesson-note-builder-view.tsx
+++ b/packages/ui-kit/lib/components/lesson-note/lesson-note-builder-view.tsx
@@ -39,6 +39,7 @@ export const LessonNoteBuilderView: FC<LessonNoteBuilderViewType> = ({
     children,
     placeholder,
     locale,
+    onDeserializationError
 }) => {
     const dictionary = getDictionary(locale);
     const [value, setValue] = useState<string>(initialValue);
@@ -89,6 +90,7 @@ export const LessonNoteBuilderView: FC<LessonNoteBuilderViewType> = ({
                 onLoseFocus={handleLoseFocus}
                 onChange={handleChange}
                 locale={locale}
+                onDeserializationError={onDeserializationError}
             />
             {children}
             {!notesSaved && !children && (

--- a/packages/ui-kit/lib/components/lesson-note/lesson-note-view.tsx
+++ b/packages/ui-kit/lib/components/lesson-note/lesson-note-view.tsx
@@ -8,6 +8,7 @@ export interface LessonNoteViewType extends isLocalAware {
     lessonTitle: string;
     lessonDescription: string;
     onClickViewLesson: () => void;
+    onDeserializationError: (message: string, error: Error) => void;
 };
 
 /**
@@ -40,6 +41,7 @@ export const LessonNoteView: FC<LessonNoteViewType> = ({
     lessonTitle,
     lessonDescription,
     onClickViewLesson,
+    onDeserializationError,
     locale,
 }) => {
     const dictionary = getDictionary(locale);
@@ -60,7 +62,7 @@ export const LessonNoteView: FC<LessonNoteViewType> = ({
                 className="bg-divider h-[1px] w-full"
             />
             <p className="text-text-secondary text-lg leading-[150%]">
-                <RichTextRenderer content={lessonDescription} />
+                <RichTextRenderer content={lessonDescription} onDeserializationError={onDeserializationError} />
             </p>
         </div>
     );

--- a/packages/ui-kit/lib/components/pre-assessment/form-renderer.tsx
+++ b/packages/ui-kit/lib/components/pre-assessment/form-renderer.tsx
@@ -91,7 +91,16 @@ export function FormElementRenderer({
             switch (element.type) {
                 case FormElementType.TextInput: {
                     const textInput = formElement as TextInputElement;
-                    value = 'content' in textInput ? deserialize(textInput.content) : [];
+
+                    const onDeserializationError = (message: string, error: Error) => {
+                        // TODO: check how to pass a callback from the parent to here
+                    }
+
+                    value = 'content' in textInput ? deserialize({
+                        serializedData: textInput.content,
+                        onError: onDeserializationError
+                    }
+                    ) : [];
                     break;
                 }
                 case FormElementType.SingleChoice: {

--- a/packages/ui-kit/lib/components/rich-text-element/editor.tsx
+++ b/packages/ui-kit/lib/components/rich-text-element/editor.tsx
@@ -108,10 +108,13 @@ export const RenderElement = ({ attributes, children, element }: RenderElementPr
  * Supports initial value parsing, custom key bindings, and a toolbar for formatting options.
  */
 export const RichTextEditor: React.FC<RichTextEditorProps> = React.memo(
-  function RichTextEditor({ name, locale, onChange, onLoseFocus, placeholder, initialValue }) {
+  function RichTextEditor({ name, locale, onChange, onLoseFocus, placeholder, initialValue, onDeserializationError }) {
 
     // Deserialize the initial value to Slate format
-    const deserializedInitialValue = deserialize(initialValue);
+    const deserializedInitialValue = deserialize({
+      serializedData: initialValue,
+      onError: onDeserializationError
+    });
 
     // Initialize the editor with history and React plugin
     const [editor] = useState(() => {

--- a/packages/ui-kit/lib/components/rich-text-element/renderer.tsx
+++ b/packages/ui-kit/lib/components/rich-text-element/renderer.tsx
@@ -3,19 +3,34 @@ import { deserialize } from './serializer';
 import { cn } from '../../utils/style-utils';
 
 
+export interface RichTextRendererProps {
+  content: string | Descendant[];
+  onDeserializationError: (message: string, error: Error) => void;
+  className?: string;
+}
+
 /**
  * SlateRenderer Component
  * 
  * Renders Slate content in a read-only format.
  * Supports both string and Descendant array as input.
  * 
- * @param {Object} props - Component properties
  * @param {string | Descendant[]} props.content - The Slate content, either as a string (which is parsed) or as a Descendant array.
+ * @param {function} props.onDeserializationError - Callback function to handle deserialization errors.
+ * @param {string} [props.className] - Optional additional class names for styling.
  */
-function RichTextRenderer({ content, className }: { content: string | Descendant[], className?: string }) {
+function RichTextRenderer({
+  content,
+  onDeserializationError,
+  className
+}: RichTextRendererProps) {
+
 
   // Deserialize the content to Slate format
-  const deserializedContent = deserialize(content);
+  const deserializedContent = deserialize({
+    serializedData: content,
+    onError: onDeserializationError
+  });
 
   return (
     <div className={cn(className)}>

--- a/packages/ui-kit/lib/components/rich-text-element/types.ts
+++ b/packages/ui-kit/lib/components/rich-text-element/types.ts
@@ -12,6 +12,7 @@ export interface RichTextEditorProps extends isLocalAware {
   initialValue: Descendant[] | undefined | string;
   onChange?: (value: Descendant[]) => void;
   onLoseFocus: (value: string) => void;
+  onDeserializationError: (message: string, error: Error) => void;
 }
 
 /**

--- a/packages/ui-kit/stories/course-builder/lesson-notes/lesson-note.stories.tsx
+++ b/packages/ui-kit/stories/course-builder/lesson-notes/lesson-note.stories.tsx
@@ -5,19 +5,26 @@ import { LessonNoteBuilderViewType, LessonNoteStudentViewType } from '../../../l
 import { LessonNoteView } from '../../../lib/components/lesson-note/lesson-note-view';
 import Banner from '../../../lib/components/banner';
 import { useState } from 'react';
+import { slateifySerialize } from '../../../lib/components/rich-text-element/serializer';
+
+
+const onDeserializationError = (message: string, error: Error) => {
+  console.error(`${message}. Error: ${error}`);
+}
 
 // --- DESIGNER MOCK DATA ---
 const designerLessonNote: LessonNoteBuilderViewType = {
   type: CourseElementType.LessonNote,
   id: 101,
   order: 1,
-  initialValue: "<p>This is a <strong>lesson note</strong> for editing.</p>",
+  initialValue: slateifySerialize("This is a sample note."),
   onChange: (value) => {
     console.log("Designer LessonNote changed:", value);
     return Math.random() < 0.5; // Simulate a 50% chance of saving successfully
   },
   placeholder: "Write your lesson notes here...",
   locale: "en",
+  onDeserializationError: onDeserializationError,
 };
 
 
@@ -41,6 +48,7 @@ const getPreviewLessonNote = (locale: "en" | "de"): LessonNoteStudentViewType =>
       }
       onClickViewLesson={() => alert("View Lesson clicked")}
       locale={locale}
+      onDeserializationError={onDeserializationError}
     />,
     <LessonNoteView
       key="note2"
@@ -53,6 +61,7 @@ const getPreviewLessonNote = (locale: "en" | "de"): LessonNoteStudentViewType =>
       }
       onClickViewLesson={() => alert("View Lesson clicked")}
       locale={locale}
+      onDeserializationError={onDeserializationError}
     />,
     <LessonNoteView
       key="note3"
@@ -65,6 +74,7 @@ const getPreviewLessonNote = (locale: "en" | "de"): LessonNoteStudentViewType =>
       }
       onClickViewLesson={() => alert("View Lesson clicked")}
       locale={locale}
+      onDeserializationError={onDeserializationError}
     />,
   ],
 });

--- a/packages/ui-kit/stories/form-element-renderer.stories.tsx
+++ b/packages/ui-kit/stories/form-element-renderer.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { FormElementRenderer } from "../lib/components/pre-assessment/form-renderer";
 import { FormElementType, FormElement } from "../lib/components/pre-assessment/types";
+import { slateifySerialize } from "../lib/components/rich-text-element/serializer";
 const meta: Meta<typeof FormElementRenderer> = {
     title: "Components/Pre-Assessment/FormElementRenderer",
     component: FormElementRenderer,
@@ -27,14 +28,14 @@ const Elements: FormElement[] = [
         id: "rich-text-1",
         type: FormElementType.RichText,
         order: 1,
-        content: "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Welcome to the pre-assessment form. Please read this information carefully before proceeding.\"}]}]"
+        content: slateifySerialize("Welcome to the pre-assessment form. Please read this information carefully before proceeding."),
     },
     {
         id: "text-input-1",
         type: FormElementType.TextInput,
         required: true,
         order: 2,
-        helperText: "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"What is your name?\"}]}]"
+        helperText: slateifySerialize("What is your name?"),
     },
     {
         id: "single-choice-1",
@@ -46,7 +47,6 @@ const Elements: FormElement[] = [
             { name: "Red", isSelected: false },
             { name: "Blue", isSelected: false },
             { name: "Green", isSelected: false }
-
         ]
     },
     {

--- a/packages/ui-kit/stories/one-out-of-three.stories.tsx
+++ b/packages/ui-kit/stories/one-out-of-three.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { OneOutOfThree, OneOutOfThreeData } from '../lib/components/out-of-three/one-out-of-three';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 /**
  * Mock messages for translations.

--- a/packages/ui-kit/stories/rich-text-renderer.stories.tsx
+++ b/packages/ui-kit/stories/rich-text-renderer.stories.tsx
@@ -1,15 +1,18 @@
-// components/RichTextRenderer.stories.tsx
-import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import RichTextRenderer from '../lib/components/rich-text-element/renderer';
 import { Descendant } from 'slate';
+import { slateifySerialize } from '../lib/components/rich-text-element/serializer';
 
 export default {
   title: 'Components/RichTextRenderer',
   component: RichTextRenderer,
 } as Meta;
 
-const Template: StoryFn<{ content: string | Descendant[] }> = (args) => (
+const onDeserializationError = (message: string, error: Error) => {
+  console.error(`${message}. Error: ${error}`);
+}
+
+const Template: StoryFn<{ content: string | Descendant[], onDeserializationError: (message: string, error: Error) => void }> = (args) => (
   <div className="bg-black text-white p-4 min-h-screen">
     <RichTextRenderer {...args} />
   </div>
@@ -17,9 +20,7 @@ const Template: StoryFn<{ content: string | Descendant[] }> = (args) => (
 
 export const BasicText = Template.bind({});
 BasicText.args = {
-  content: `[{"type":"paragraph","children":[{"text":"This is a basic paragraph."}]}]`
-
-  ,
+  content: slateifySerialize("This is a basic text.")
 };
 
 export const BoldItalicUnderline = Template.bind({});
@@ -34,6 +35,7 @@ BoldItalicUnderline.args = {
       ],
     },
   ],
+  onDeserializationError,
 };
 
 export const Strikethrough = Template.bind({});
@@ -44,6 +46,8 @@ Strikethrough.args = {
       children: [{ text: 'This text has a strikethrough.', strikethrough: true }],
     },
   ],
+  onDeserializationError,
+
 };
 
 export const Code = Template.bind({});
@@ -54,6 +58,7 @@ Code.args = {
       children: [{ text: 'This is inline code.', code: true }],
     },
   ],
+  onDeserializationError,
 };
 
 export const Highlight = Template.bind({});
@@ -64,6 +69,7 @@ Highlight.args = {
       children: [{ text: 'This text is highlighted.', highlight: true }],
     },
   ],
+  onDeserializationError,
 };
 
 export const Superscript = Template.bind({});
@@ -74,6 +80,7 @@ Superscript.args = {
       children: [{ text: 'Superscript', superscript: true }],
     },
   ],
+  onDeserializationError,
 };
 
 export const Subscript = Template.bind({});
@@ -84,6 +91,7 @@ Subscript.args = {
       children: [{ text: 'Subscript', subscript: true }],
     },
   ],
+  onDeserializationError,
 };
 
 export const OrderedList = Template.bind({});
@@ -98,6 +106,7 @@ OrderedList.args = {
       ],
     },
   ],
+  onDeserializationError,
 };
 
 export const UnorderedList = Template.bind({});
@@ -112,6 +121,7 @@ UnorderedList.args = {
       ],
     },
   ],
+  onDeserializationError,
 };
 
 export const MixedContent = Template.bind({});
@@ -145,4 +155,5 @@ MixedContent.args = {
       ],
     },
   ],
+  onDeserializationError,
 };

--- a/packages/ui-kit/tests/lesson-note-builder-view.test.tsx
+++ b/packages/ui-kit/tests/lesson-note-builder-view.test.tsx
@@ -15,6 +15,11 @@ const mockDictionary = {
   },
 };
 
+const mockOnDeserializationError = vi.fn((message: string, error: Error): void => {
+  // This is empty on purpose, don't remove this comment or ESLint will complain
+});
+
+
 // Mock getDictionary
 vi.mock('@maany_shr/e-class-translations', () => ({
   getDictionary: () => mockDictionary,
@@ -35,7 +40,6 @@ vi.mock('../lib/components/banner', () => ({
 
 // Mock RichTextEditor
 const mockOnChange = vi.fn(() => true);
-const mockOnLoseFocus = vi.fn();
 vi.mock('../lib/components/rich-text-element/editor', () => ({
   __esModule: true,
   default: ({ initialValue, placeholder, onChange, onLoseFocus, name, locale }: any) => (
@@ -51,7 +55,7 @@ vi.mock('../lib/components/rich-text-element/editor', () => ({
 
 describe('LessonNoteBuilderView Component', () => {
   const mockProps = {
-    type: CourseElementType.LessonNote,
+    type: CourseElementType.LessonNote as CourseElementType.LessonNote,
     id: 1,
     order: 1,
     initialValue: 'Initial lesson note',
@@ -59,6 +63,7 @@ describe('LessonNoteBuilderView Component', () => {
     placeholder: 'Write your lesson notes here...',
     locale: 'en' as TLocale,
     children: undefined,
+    onDeserializationError: mockOnDeserializationError,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Introduce an `onDeserializationError` callback for all components utilizing the rich text editor and renderer. This enhancement allows better error handling during the deserialization process. Marked areas in course components indicate where further implementation is needed.

TODO @anilrise11: the course components that use rich text will need to pass this callback down. Marked the places with TODO notes

Fix #203