### PR TITLE
[TSK-1123] ui-kit: AddCoachModal (no coaches found skeleton)

### DIFF
--- a/packages/ui-kit/lib/components/add-coach-modal.tsx
+++ b/packages/ui-kit/lib/components/add-coach-modal.tsx
@@ -27,10 +27,11 @@ export interface AddCoachModalProps extends isLocalAware {
 /**
  * A modal component for searching and adding coaches to a selection list.
  *
- * Provides a simple UI to:
+ * Provides a UI to:
  * 1. Search coaches by name.
  * 2. Add a coach by triggering a callback with the coach's ID.
  * 3. View coach details including avatar and average rating.
+ * 4. Display a "no coaches found" state with a loading skeleton UI when search results are empty.
  *
  * The component supports localization via the `locale` prop and uses translated
  * labels from the dictionary system in `@maany_shr/e-class-translations`.
@@ -115,7 +116,7 @@ export const AddCoachModal = ({
                     inputPlaceholder={dictionary.searchLabel}
                     leftContent={<IconSearch />}
                 />
-                {/* No coaches found skeleton */}
+                {/* No coaches found & skeleton */}
                 {searchContent.trim() && (
                     <ul className="max-h-70 overflow-y-auto pr-2">
                         {filteredCoaches.length === 0 ? (
@@ -123,6 +124,24 @@ export const AddCoachModal = ({
                                 <h6 className="text-text-primary mb-4">
                                     {dictionary.noFoundLabel}
                                 </h6>
+                                <div className="flex justify-between items-center rounded-lg gap-2 p-4">
+                                    {/* Skeleton avatar */}
+                                    <div className="w-18 h-15 items-end rounded-full bg-base-neutral-700 animate-pulse" />
+                                    {/* Skeleton title and rating*/}
+                                    <div className="flex flex-col items-start gap-3 w-full animate-pulse">
+                                        <div className="w-50 h-6 bg-base-neutral-700 rounded-lg" />
+                                        <div className="w-30 h-4 bg-base-neutral-700 rounded-lg" />
+                                    </div>
+                                </div>
+                                <div className="flex justify-between items-center rounded-lg gap-2 p-4">
+                                    {/* Skeleton avatar */}
+                                    <div className="w-18 h-15 items-end rounded-full bg-base-neutral-700 animate-pulse" />
+                                    {/* Skeleton title and rating*/}
+                                    <div className="flex flex-col items-start gap-3 w-full animate-pulse">
+                                        <div className="w-50 h-6 bg-base-neutral-700 rounded-lg" />
+                                        <div className="w-30 h-4 bg-base-neutral-700 rounded-lg" />
+                                    </div>
+                                </div>
                             </li>
                         ) : (
                             filteredCoaches.map((coach) => {

--- a/packages/ui-kit/lib/components/add-coach-modal.tsx
+++ b/packages/ui-kit/lib/components/add-coach-modal.tsx
@@ -24,6 +24,20 @@ export interface AddCoachModalProps extends isLocalAware {
     addedCoachIds?: string[];
 }
 
+
+const SkeletonCoachItem = () => (
+    <div className="flex justify-between items-center rounded-lg gap-2 p-4">
+        {/* Skeleton avatar */}
+        <div className="w-18 h-15 items-end rounded-full bg-base-neutral-700 animate-pulse" />
+        {/* Skeleton title and rating*/}
+        <div className="flex flex-col items-start gap-3 w-full animate-pulse">
+            <div className="w-50 h-6 bg-base-neutral-700 rounded-lg" />
+            <div className="w-30 h-4 bg-base-neutral-700 rounded-lg" />
+        </div>
+    </div>
+
+);
+
 /**
  * A modal component for searching and adding coaches to a selection list.
  *
@@ -124,24 +138,8 @@ export const AddCoachModal = ({
                                 <h6 className="text-text-primary mb-4">
                                     {dictionary.noFoundLabel}
                                 </h6>
-                                <div className="flex justify-between items-center rounded-lg gap-2 p-4">
-                                    {/* Skeleton avatar */}
-                                    <div className="w-18 h-15 items-end rounded-full bg-base-neutral-700 animate-pulse" />
-                                    {/* Skeleton title and rating*/}
-                                    <div className="flex flex-col items-start gap-3 w-full animate-pulse">
-                                        <div className="w-50 h-6 bg-base-neutral-700 rounded-lg" />
-                                        <div className="w-30 h-4 bg-base-neutral-700 rounded-lg" />
-                                    </div>
-                                </div>
-                                <div className="flex justify-between items-center rounded-lg gap-2 p-4">
-                                    {/* Skeleton avatar */}
-                                    <div className="w-18 h-15 items-end rounded-full bg-base-neutral-700 animate-pulse" />
-                                    {/* Skeleton title and rating*/}
-                                    <div className="flex flex-col items-start gap-3 w-full animate-pulse">
-                                        <div className="w-50 h-6 bg-base-neutral-700 rounded-lg" />
-                                        <div className="w-30 h-4 bg-base-neutral-700 rounded-lg" />
-                                    </div>
-                                </div>
+                                <SkeletonCoachItem />
+                                <SkeletonCoachItem />
                             </li>
                         ) : (
                             filteredCoaches.map((coach) => {

--- a/packages/ui-kit/stories/add-coach-modal.stories.tsx
+++ b/packages/ui-kit/stories/add-coach-modal.stories.tsx
@@ -1,5 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { AddCoachModal } from '../lib/components/add-coach-modal';
+import {
+    AddCoachModal,
+    AddCoachModalProps,
+} from '../lib/components/add-coach-modal';
+import { useState } from 'react';
 
 export default {
     title: 'Components/AddCoachModal',
@@ -57,11 +61,35 @@ const mockCoaches = [
     },
 ];
 
+const StatefulAddCoachModal = (args: AddCoachModalProps) => {
+    const [addedCoachIds, setAddedCoachIds] = useState<string[]>(
+        args.addedCoachIds ?? [],
+    );
+
+    const handleAddCoach = (id: string) => {
+        if (!addedCoachIds.includes(id)) {
+            const updatedIds = [...addedCoachIds, id];
+            setAddedCoachIds(updatedIds);
+            alert(`Added coach with ID: ${id}`);
+        } else {
+            alert(`Coach with ID: ${id} is already added.`);
+        }
+    };
+
+    return (
+        <AddCoachModal
+            {...args}
+            addedCoachIds={addedCoachIds}
+            onAdd={handleAddCoach}
+        />
+    );
+};
+
 export const Default: Story = {
+    render: (args) => <StatefulAddCoachModal {...args} />,
     args: {
         locale: 'en',
         onClose: () => alert('Modal closed'),
-        onAdd: (id: string) => alert(`Added coach with ID: ${id}`),
         content: mockCoaches,
         addedCoachIds: ['coach-2'],
     },


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes made in this pull request for UI-Kit components. -->

- Component name: `AddCoachModal`

---


## React Best Practices Checklist

- [x] I have avoided **unnecessary re-renders** by using composition (`children` as props), whenever possible. This applies, in particular, to composite components (like lists of components, and the like).
- [x] **I have designed my components as server-side whenever possible**—I have not used `useState`, `useEffect`, `useContext`, or any other React hook that works with "use client" without a good reason.
- [x] **I have not put props in state**—in general, props should remain as props unless the component needs an `initialValue`, and judiciously manage its own independent state detached from the parent component.
    - If I have stored props in state, I have explained where exactly and justified it with a solid reason here below:
    
- [x] **I have avoided using Context** in any critical component in terms of performance
    - If I have used Context, I have explained where exactly and justified it with a solid reason here below:


## General Checklist

- [x] I have run the lint, build, and test commands locally, as explained in the README, before creating this PR to ensure the code is clean and functional.
- [x] My changes align with the **core models** that have been discussed and agreed upon.
- [x] The component design has been compared to the **Figma design** to ensure consistency.
- [x] The **component is fully responsive** and behaves as expected across different screen sizes.
- [x] The component **supports keyboard web accessibility** (if applicable).
- [x] I have written **unit tests** or **integration tests** to cover the component's functionality above the coverage threshold.
- [x] I have updated the **documentation** for the component, including usage examples and guidelines.
- [x] I have **commented** my code, particularly in complex or non-obvious areas.
- [x] The **component is properly exported** for use in other parts of the application.
