### PR TITLE
ui-kit: Notifications / RecentActivity component revision 

### DIFF
--- a/packages/ui-kit/lib/components/notifications/activity.tsx
+++ b/packages/ui-kit/lib/components/notifications/activity.tsx
@@ -127,89 +127,51 @@ export const Activity: FC<ActivityProps> = ({
       data-testid="activity"
       onClick={onClickActivity?.(action?.url ?? '')}
       className={clsx(
-        `flex p-2 my-[0.125rem] flex-col items-center w-full border-b border-divider cursor-pointer ${
+        `flex p-2 my-[0.125rem] w-full border-b border-divider cursor-pointer overflow-hidden ${
           isRead ? 'bg-transparent' : 'bg-base-neutral-800 rounded-small'
         }`,
-        layout === 'horizontal' ? 'flex-row items-center gap-4' : 'flex-col items-start',
+        // Responsive layout: vertical on mobile, horizontal on larger screens  
+        'flex-col items-start space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0',
         className,
       )}
     >
-      {/* Horizontal layout */}
-      {layout === 'horizontal' && (
-        <div className="flex gap-4 items-center w-full justify-between">
-          <div className="flex flex-col items-start gap-1">
-            <p className="text-sm text-text-primary leading-[150%] text-left">{message}</p>
-            {children}
-            <div className="flex gap-2">
-              {platformName && (
-                <p className="text-xs text-text-secondary leading-[100%]">{platformName}</p>
-              )}
-              {recipients > 0 && (
-                <p className="text-xs text-text-secondary leading-[100%]">
-                  {recipientsText} {recipients}
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="flex gap-4 items-baseline">
-              {action?.title && (
-                <Button
-                  variant="text"
-                  size="small"
-                  text={action.title}
-                  className="whitespace-nowrap p-0 max-w-[15rem]"
-                />
-              )}
-              {formattedDateTime && (
-                <p className="text-xs text-text-secondary leading-[100%] whitespace-nowrap">
-                  {formattedDateTime.formattedDate} {atText} {formattedDateTime.formattedTime}
-                </p>
-              )}
-            </div>
-            {!isRead && (
-              <span className="w-2 h-2 rounded-full bg-button-primary-fill flex-shrink-0" />
-            )}
-          </div>
+      {/* Content section */}
+      <div className="flex flex-col items-start gap-1 min-w-0 flex-1">
+        <p className="text-sm text-text-primary leading-[150%] text-left text-wrap break-words">{message}</p>
+        {children}
+        <div className="flex flex-wrap gap-2 text-xs text-text-secondary">
+          {platformName && (
+            <p className="leading-[100%]">{platformName}</p>
+          )}
+          {recipients > 0 && (
+            <p className="leading-[100%]">
+              {recipientsText} {recipients}
+            </p>
+          )}
         </div>
-      )}
-      {/* Vertical layout */}
-      {layout === 'vertical' && (
-        <>
-          <div className="flex justify-between items-start w-full gap-4">
-            <p className="text-sm text-text-primary leading-[150%] text-left">{message}</p>
-            {!isRead && (
-              <span className="w-2 h-2 rounded-full bg-button-primary-fill flex-shrink-0" />
-            )}
-          </div>
-          {children}
-          <div className="flex justify-between items-center w-full">
-            {action?.title && (
-              <Button
-                variant="text"
-                size="small"
-                text={action.title}
-                className="whitespace-nowrap p-0 max-w-[20rem]"
-              />
-            )}
-            <div className="flex gap-2 items-center">
-              {recipients > 0 && (
-                <p className="text-xs text-text-secondary leading-[100%]">
-                  {recipientsText} {recipients}
-                </p>
-              )}
-              {platformName && (
-                <p className="text-xs text-text-secondary leading-[100%]">{platformName}</p>
-              )}
-              {formattedDateTime && (
-                <p className="text-xs text-text-secondary leading-[100%] whitespace-nowrap">
-                  {formattedDateTime.formattedDate} {atText} {formattedDateTime.formattedTime}
-                </p>
-              )}
-            </div>
-          </div>
-        </>
-      )}
+      </div>
+      
+      {/* Action and metadata section */}
+      <div className="flex items-center gap-2 flex-shrink-0 w-full md:w-auto md:justify-end">
+        <div className="flex flex-col md:flex-row md:items-center gap-2 flex-1 md:flex-initial">
+          {action?.title && (
+            <Button
+              variant="text"
+              size="small"
+              text={action.title}
+              className="p-0 truncate max-w-xs md:max-w-sm text-left"
+            />
+          )}
+          {formattedDateTime && (
+            <p className="text-xs text-text-secondary leading-[100%] whitespace-nowrap">
+              {formattedDateTime.formattedDate} {atText} {formattedDateTime.formattedTime}
+            </p>
+          )}
+        </div>
+        {!isRead && (
+          <span className="w-2 h-2 rounded-full bg-button-primary-fill flex-shrink-0" />
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/ui-kit/lib/components/notifications/activity.tsx
+++ b/packages/ui-kit/lib/components/notifications/activity.tsx
@@ -127,49 +127,48 @@ export const Activity: FC<ActivityProps> = ({
       data-testid="activity"
       onClick={onClickActivity?.(action?.url ?? '')}
       className={clsx(
-        `flex p-2 my-[0.125rem] w-full border-b border-divider cursor-pointer overflow-hidden ${
-          isRead ? 'bg-transparent' : 'bg-base-neutral-800 rounded-small'
+        `flex p-2 my-[0.125rem] w-full border-b border-divider cursor-pointer overflow-hidden relative ${isRead ? 'bg-transparent' : 'bg-base-neutral-800 rounded-small'
         }`,
         // Responsive layout: vertical on mobile, horizontal on larger screens  
-        'flex-col items-start space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0',
+        'flex-col items-start md:flex-row md:items-center md:justify-between',
         className,
       )}
     >
+      <div className="absolute top-2 right-2 z-50">
+        {!isRead && (
+          <span className="w-2 h-2 rounded-full bg-button-primary-fill flex-shrink-0 block" />
+        )}
+      </div>
       {/* Content section */}
       <div className="flex flex-col items-start gap-1 min-w-0 flex-1">
-        <p className="text-sm text-text-primary leading-[150%] text-left text-wrap break-words">{message}</p>
+        <p className="text-sm text-text-primary leading-[150%] text-left text-wrap break-words w-[96%]">{message}</p>
         {children}
-        <div className="flex flex-wrap gap-2 text-xs text-text-secondary">
+        <div className="flex flex-wrap gap-2 text-xs text-text-secondary md:justify-start justify-end w-full">
           {platformName && (
             <p className="leading-[100%]">{platformName}</p>
           )}
           {recipients > 0 && (
             <p className="leading-[100%]">
-              {recipientsText} {recipients}
+              {recipients} {recipientsText}
             </p>
           )}
         </div>
       </div>
-      
+
       {/* Action and metadata section */}
-      <div className="flex items-center gap-2 flex-shrink-0 w-full md:w-auto md:justify-end">
-        <div className="flex flex-col md:flex-row md:items-center gap-2 flex-1 md:flex-initial">
-          {action?.title && (
-            <Button
-              variant="text"
-              size="small"
-              text={action.title}
-              className="p-0 truncate max-w-xs md:max-w-sm text-left"
-            />
-          )}
-          {formattedDateTime && (
-            <p className="text-xs text-text-secondary leading-[100%] whitespace-nowrap">
-              {formattedDateTime.formattedDate} {atText} {formattedDateTime.formattedTime}
-            </p>
-          )}
-        </div>
-        {!isRead && (
-          <span className="w-2 h-2 rounded-full bg-button-primary-fill flex-shrink-0" />
+      <div className="flex flex-row items-center justify-between gap-2 flex-shrink-0 w-full md:w-auto">
+        {action?.title && (
+          <Button
+            variant="text"
+            size="small"
+            text={action.title}
+            className="p-0 truncate"
+          />
+        )}
+        {formattedDateTime && (
+          <p className="text-xs text-text-secondary leading-[100%] whitespace-nowrap">
+            {formattedDateTime.formattedDate} {atText} {formattedDateTime.formattedTime}
+          </p>
         )}
       </div>
     </div>

--- a/packages/ui-kit/lib/components/notifications/recent-activity.tsx
+++ b/packages/ui-kit/lib/components/notifications/recent-activity.tsx
@@ -54,10 +54,10 @@ export const RecentActivity: FC<RecentActivityProps> = ({
   const displayedChildren = allChildren.slice(0, maxActivities);
 
   return (
-    <div className={`flex flex-col gap-2 items-center ${className}`}>
+    <div className={`flex flex-col gap-2 items-center ${className || ''}`}>
       {variation === 'Feed' && (
-        <div className="flex w-full items-center justify-between">
-          <p className="text-xl text-base-white font-bold text-left">
+        <div className="flex w-full items-start justify-between gap-2 sm:items-center">
+          <p className="text-xl text-base-white font-bold text-left min-w-0 flex-1">
             {dictionary?.components?.recentActivity?.recentActivity}
           </p>
           {onClickMarkAllAsRead && (
@@ -66,20 +66,22 @@ export const RecentActivity: FC<RecentActivityProps> = ({
               size="medium"
               text={dictionary?.components?.recentActivity?.markAllAsRead}
               hasIconLeft
-              className="text-right p-0"
+              className="text-right p-0 flex-shrink-0 max-w-fit whitespace-nowrap"
               iconLeft={<IconCheckDouble size="6" />}
               onClick={onClickMarkAllAsRead}
             />
           )}
         </div>
       )}
-      <div className="flex p-2 flex-col w-full bg-card-fill border border-card-stroke rounded-medium">
-        {displayedChildren}
+      <div className="flex p-2 flex-col w-full bg-card-fill border border-card-stroke rounded-medium overflow-hidden">
+        <div className="space-y-2">
+          {displayedChildren}
+        </div>
         {allChildren.length > maxActivities && (
           <Button
             text={dictionary?.components?.recentActivity?.viewAll}
             variant="text"
-            className="p-0"
+            className="p-0 mt-2 self-start"
             onClick={onClickViewAll}
           />
         )}

--- a/packages/ui-kit/lib/components/notifications/recent-activity.tsx
+++ b/packages/ui-kit/lib/components/notifications/recent-activity.tsx
@@ -81,7 +81,7 @@ export const RecentActivity: FC<RecentActivityProps> = ({
           <Button
             text={dictionary?.components?.recentActivity?.viewAll}
             variant="text"
-            className="p-0 mt-2 self-start"
+            className="p-0 mt-2"
             onClick={onClickViewAll}
           />
         )}

--- a/packages/ui-kit/stories/notifications/recent-activity.stories.tsx
+++ b/packages/ui-kit/stories/notifications/recent-activity.stories.tsx
@@ -9,7 +9,7 @@ const mockMessages = {};
 const mockActivities = [
   {
     message:
-      'Coach Jane Smith accepted your request to reschedule the coaching session.',
+      'Coach Jane Smith accepted your request to reschedule the coaching session.Coach Jane Smith accepted your request to reschedule the coaching session.',
     action: { title: 'Session details', url: 'https://google.com' },
     timestamp: '2024-08-07T21:17:00Z',
     isRead: false,
@@ -72,7 +72,7 @@ const meta: Meta<typeof RecentActivity> = {
   decorators: [
     (Story) => (
       <NextIntlClientProvider locale="en" messages={mockMessages}>
-        <div className="w-full max-w-3xl">
+        <div className="w-full max-w-4xl">
           <Story />
         </div>
       </NextIntlClientProvider>


### PR DESCRIPTION
## Notifications → RecentActivity

There’s an overflow on devices that we shouldn't happen, as per the Figma:

<img width="924" height="560" alt="Image" src="https://github.com/user-attachments/assets/41b080a5-c504-4d06-856b-d7b2de6ecf18" />

<img width="2073" height="1208" alt="Image" src="https://github.com/user-attachments/assets/fa8586c9-c548-4229-a91d-40f623220613" />