### PR TITLE
Fix: Use correct type TFileUploadRequest for file upload callbacks in LinkEdit component

### DIFF
--- a/packages/ui-kit/lib/components/coach/coach-notes.tsx
+++ b/packages/ui-kit/lib/components/coach/coach-notes.tsx
@@ -280,7 +280,7 @@ function CoachNotesCreate({
                         )}
                     </div>
                 </div>
-                <div
+                {editingLinkIndex === null && <div
                     className="flex items-center mt-4 gap-2"
                     role="group"
                     aria-label="Add link divider"
@@ -296,7 +296,7 @@ function CoachNotesCreate({
                         disabled={editingLinkIndex !== null}
                     />
                     <hr className="flex-grow border-t border-divider" />
-                </div>
+                </div>}
             </div>
 
             <div className="flex w-full  items-center gap-4">

--- a/packages/ui-kit/lib/components/coach/coach-notes.tsx
+++ b/packages/ui-kit/lib/components/coach/coach-notes.tsx
@@ -48,8 +48,7 @@ export interface coachNotesProps extends isLocalAware {
 export interface coachNotesViewProps extends isLocalAware {
     noteDescription: string;
     noteLinks: noteLink[];
-    includeInMaterials: boolean;
-    onExploreCourses?: () => void; // Optional callback for explore courses button
+    onExploreCourses: () => void;
 }
 function CoachNotesCreate({
     noteDescription: initialNoteDescription,
@@ -151,7 +150,6 @@ function CoachNotesCreate({
 
     const handleDescriptionChange = (values: Descendant[]) => {
         setNoteDescription(values);
-       
     };
 
     return (
@@ -170,7 +168,7 @@ function CoachNotesCreate({
                     onDeserializationError={(error) =>
                         console.error('Deserialization error:', error)
                     }
-                    onLoseFocus={(values) =>  onNoteDescriptionChange(values)}
+                    onLoseFocus={(values) => onNoteDescriptionChange(values)}
                     onChange={handleDescriptionChange}
                 />
             </div>
@@ -349,7 +347,6 @@ function CoachNotesCreate({
 function CoachNotesView({
     noteDescription,
     noteLinks,
-    includeInMaterials,
     locale,
     onExploreCourses,
 }: coachNotesViewProps) {
@@ -367,8 +364,8 @@ function CoachNotesView({
                 return content.length > 0;
             }
             return false;
-        } catch {
-            // If parsing fails, assume no valid description
+        } catch (_error) {
+            // Parsing failed, likely due to invalid JSON. Returning false as a fallback. 
             return false;
         }
     };

--- a/packages/ui-kit/lib/components/coach/coach-notes.tsx
+++ b/packages/ui-kit/lib/components/coach/coach-notes.tsx
@@ -151,7 +151,7 @@ function CoachNotesCreate({
 
     const handleDescriptionChange = (values: Descendant[]) => {
         setNoteDescription(values);
-        onNoteDescriptionChange(serialize(values));
+       
     };
 
     return (
@@ -170,9 +170,7 @@ function CoachNotesCreate({
                     onDeserializationError={(error) =>
                         console.error('Deserialization error:', error)
                     }
-                    onLoseFocus={() => {
-                        /* lose focus returns serialized string; nothing needed here */
-                    }}
+                    onLoseFocus={(values) =>  onNoteDescriptionChange(values)}
                     onChange={handleDescriptionChange}
                 />
             </div>

--- a/packages/ui-kit/lib/components/coach/coach-notes.tsx
+++ b/packages/ui-kit/lib/components/coach/coach-notes.tsx
@@ -34,9 +34,9 @@ export interface coachNotesProps extends isLocalAware {
     ) => void;
     onImageChange: (
         index: number,
-        image: fileMetadata.TFileMetadata,
+        fileRequest: fileMetadata.TFileUploadRequest,
         abortSignal?: AbortSignal,
-    ) => void;
+    ) => Promise<fileMetadata.TFileMetadata>;
     onDeleteIcon: (index: number) => void;
     onNoteLinksChange: (noteLinks: noteLink[]) => void;
     onIncludeInMaterialsChange: (includeInMaterials: boolean) => void;
@@ -199,8 +199,8 @@ function CoachNotesCreate({
                         <div key={index} className="w-full">
                             <div
                                 className={`w-full overflow-hidden transition-all duration-300 ease-in-out ${editingLinkIndex === index
-                                        ? 'max-h-[500px]'
-                                        : 'max-h-0'
+                                    ? 'max-h-[500px]'
+                                    : 'max-h-0'
                                     }`}
                             >
                                 {editingLinkIndex === index && (
@@ -220,11 +220,11 @@ function CoachNotesCreate({
                                             )
                                         }
                                         onDiscard={() => handleDiscard(index)}
-                                        onImageChange={(image, abortSignal) =>
-                                            onImageChange(
+                                        onImageChange={async (fileRequest, abortSignal) =>
+                                            await onImageChange(
                                                 index,
-                                                image,
-                                                abortSignal,
+                                                fileRequest,
+                                                abortSignal
                                             )
                                         }
                                         onDeleteIcon={() => onDeleteIcon(index)}
@@ -245,8 +245,8 @@ function CoachNotesCreate({
                     ))}
                     <div
                         className={`w-full overflow-hidden transition-all duration-300 ease-in-out ${editingLinkIndex === initialNoteLinks.length
-                                ? 'max-h-[500px]'
-                                : 'max-h-0'
+                            ? 'max-h-[500px]'
+                            : 'max-h-0'
                             }`}
                         key={initialNoteLinks.length}
                     >
@@ -265,10 +265,10 @@ function CoachNotesCreate({
                                 onDiscard={() =>
                                     handleDiscard(initialNoteLinks.length)
                                 }
-                                onImageChange={(image, abortSignal) =>
-                                    onImageChange(
+                                onImageChange={async (fileRequest, abortSignal) =>
+                                    await onImageChange(
                                         initialNoteLinks.length,
-                                        image,
+                                        fileRequest,
                                         abortSignal,
                                     )
                                 }
@@ -369,7 +369,7 @@ function CoachNotesView({
                 return content.length > 0;
             }
             return false;
-        } catch (error) {
+        } catch {
             // If parsing fails, assume no valid description
             return false;
         }

--- a/packages/ui-kit/stories/coach-notes-edit-dialog.stories.tsx
+++ b/packages/ui-kit/stories/coach-notes-edit-dialog.stories.tsx
@@ -77,9 +77,25 @@ const CoachNotesEditDialogWrapper = ({
 
     const handleImageChange = async (
         index: number,
-        image: fileMetadata.TFileMetadata,
-    ) => {
-        console.log('Image change:', index, image.name);
+        fileRequest: fileMetadata.TFileUploadRequest,
+        abortSignal?: AbortSignal,
+    ): Promise<fileMetadata.TFileMetadata> => {
+        console.log('Image change:', index, fileRequest.name);
+
+        // Create a mock response for the upload
+        const uploadedFile: fileMetadata.TFileMetadata = {
+            id: fileRequest.id,
+            name: fileRequest.name,
+            mimeType: fileRequest.file.type,
+            size: fileRequest.file.size,
+            category: 'image',
+            status: 'available',
+            url: URL.createObjectURL(fileRequest.file),
+            thumbnailUrl: URL.createObjectURL(fileRequest.file),
+            checksum: 'mock-checksum',
+        };
+
+        return uploadedFile;
     };
 
     const handleDeleteIcon = (index: number) => {
@@ -88,7 +104,11 @@ const CoachNotesEditDialogWrapper = ({
 
     const handlePublish = (
         description: string,
-        links: any[],
+        links: Array<{
+            title: string;
+            url: string;
+            customIconMetadata?: fileMetadata.TFileMetadata;
+        }>,
         includeInMaterials: boolean,
     ) => {
         console.log('Published:', { description, links, includeInMaterials });
@@ -111,24 +131,24 @@ const CoachNotesEditDialogWrapper = ({
                 onClick={() => setIsOpen(true)}
             />
 
-      <CoachNotesEditDialog
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        noteDescription={noteDescription}
-        noteLinks={noteLinks}
-        includeInMaterials={includeInMaterials}
-        locale="en"
-        onPublish={handlePublish}
-        onBack={handleBack}
-        onImageChange={handleImageChange}
-        onDeleteIcon={handleDeleteIcon}
-        onNoteLinksChange={setNoteLinks}
-        onIncludeInMaterialsChange={setIncludeInMaterials}
-        onNoteDescriptionChange={setNoteDescription}
-        isEditMode={true}
-      />
-    </div>
-  );
+            <CoachNotesEditDialog
+                isOpen={isOpen}
+                onOpenChange={setIsOpen}
+                noteDescription={noteDescription}
+                noteLinks={noteLinks}
+                includeInMaterials={includeInMaterials}
+                locale="en"
+                onPublish={handlePublish}
+                onBack={handleBack}
+                onImageChange={handleImageChange}
+                onDeleteIcon={handleDeleteIcon}
+                onNoteLinksChange={setNoteLinks}
+                onIncludeInMaterialsChange={setIncludeInMaterials}
+                onNoteDescriptionChange={setNoteDescription}
+                isEditMode={true}
+            />
+        </div>
+    );
 };
 
 const meta: Meta<typeof CoachNotesEditDialog> = {

--- a/packages/ui-kit/stories/coach-notes-edit-dialog.stories.tsx
+++ b/packages/ui-kit/stories/coach-notes-edit-dialog.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { NextIntlClientProvider } from 'next-intl';
 import { CoachNotesEditDialog } from '../lib/components/coach/coach-notes-edit-dialog';

--- a/packages/ui-kit/stories/coach-notes.stories.tsx
+++ b/packages/ui-kit/stories/coach-notes.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { CoachNotesCreate, CoachNotesView } from '../lib/components/coach/coach-notes';
 import type { Descendant } from 'slate';
@@ -201,7 +201,6 @@ export const ViewOnly = () => (
   <CoachNotesView
     noteDescription={JSON.stringify(sampleDescription)}
     noteLinks={sampleLinks}
-    includeInMaterials={true}
     locale="en"
     onExploreCourses={() => alert('onExploreCourses')}
   />
@@ -211,7 +210,6 @@ export const EmptyState = () => (
   <CoachNotesView
     noteDescription={JSON.stringify(emptyDescription)}
     noteLinks={[]}
-    includeInMaterials={false}
     locale="en"
     onExploreCourses={() => alert('onExploreCourses')}
   />

--- a/packages/ui-kit/stories/coach-notes.stories.tsx
+++ b/packages/ui-kit/stories/coach-notes.stories.tsx
@@ -67,7 +67,7 @@ const CoachNotesWrapper = ({
   const handleImageChange = async (index: number, fileRequest: fileMetadata.TFileUploadRequest, abortSignal?: AbortSignal): Promise<fileMetadata.TFileMetadata> => {
     console.log('Starting upload for link at index:', index, 'file:', fileRequest.name);
 
-    // // Create temporary metadata for UI state
+
     const processingFile: fileMetadata.TFileMetadata = {
       id: fileRequest.id,
       name: fileRequest.name,
@@ -78,22 +78,7 @@ const CoachNotesWrapper = ({
       url: URL.createObjectURL(fileRequest.file),
       thumbnailUrl: URL.createObjectURL(fileRequest.file),
       checksum: '',
-    };
-
-    // // Use functional update to ensure we get the latest state
-    // setNoteLinks(currentLinks => {
-    //   const updatedLinks = [...currentLinks];
-    //   // Handle new link case - extend array if index equals length
-    //   if (index >= currentLinks.length) {
-    //     updatedLinks.push({ title: '', url: '', customIconMetadata: processingFile });
-    //   } else {
-    //     updatedLinks[index] = {
-    //       ...updatedLinks[index],
-    //       customIconMetadata: processingFile,
-    //     };
-    //   }
-    //   return updatedLinks;
-    // });
+    }
 
     try {
       // Simulate upload with setTimeout that can be aborted
@@ -122,14 +107,15 @@ const CoachNotesWrapper = ({
       setNoteLinks(currentLinks => {
         const finalLinks = [...currentLinks];
 
-        if (index >= currentLinks.length) {
-          finalLinks.push({ title: '', url: '', customIconMetadata: completedFile });
-        } else {
+        // Only update existing links, don't create new ones automatically
+        if (index < currentLinks.length) {
           finalLinks[index] = {
             ...finalLinks[index],
             customIconMetadata: completedFile,
           };
         }
+        // Note: We don't automatically add new links here anymore
+        // Links should only be added when user clicks "Save" with valid data
         return finalLinks;
       });
       console.log('File upload completed for link at index:', index, completedFile);

--- a/packages/ui-kit/stories/link-edit.stories.tsx
+++ b/packages/ui-kit/stories/link-edit.stories.tsx
@@ -81,7 +81,7 @@ const LinkEditWithState = (props: LinkEditProps) => {
             thumbnailUrl: URL.createObjectURL(fileRequest.file),
             checksum: '',
         };
-        setCustomIcon(processingFile);
+
 
         try {
             // Simulate upload with setTimeout that can be aborted
@@ -134,7 +134,6 @@ const LinkEditWithState = (props: LinkEditProps) => {
         console.log('onDeleteIcon', id);
         if (customIcon && customIcon.id === id) setCustomIcon(null);
     };
-    console.log(customIcon, 'customIcon');
 
     return (
         <LinkEdit

--- a/packages/ui-kit/tests/coach-notes.test.tsx
+++ b/packages/ui-kit/tests/coach-notes.test.tsx
@@ -23,12 +23,13 @@ interface ContentNode {
 
 // Mock the rich text editor components
 vitest.mock('../lib/components/rich-text-element/editor', () => ({
-    default: function MockRichTextEditor({ onChange, placeholder }: MockRichTextEditorProps) {
+    default: function MockRichTextEditor({ onChange, onLoseFocus, placeholder }: MockRichTextEditorProps & { onLoseFocus?: (value: unknown) => void }) {
         return (
             <textarea
                 data-testid="rich-text-editor"
                 placeholder={placeholder}
                 onChange={(e) => onChange([{ type: 'paragraph', children: [{ text: e.target.value }] }])}
+                onBlur={(e) => onLoseFocus && onLoseFocus([{ type: 'paragraph', children: [{ text: e.target.value }] }])}
             />
         );
     }
@@ -122,12 +123,16 @@ describe('CoachNotesCreate', () => {
         expect(defaultProps.onIncludeInMaterialsChange).toHaveBeenCalledWith(true);
     });
 
-    it('handles description change', () => {
+    it('calls onNoteDescriptionChange only on blur (lose focus)', () => {
         render(<CoachNotesCreate {...defaultProps} />);
 
         const editor = screen.getByTestId('rich-text-editor');
+        // Simulate user typing (should NOT call onNoteDescriptionChange)
         fireEvent.change(editor, { target: { value: 'New content' } });
+        expect(defaultProps.onNoteDescriptionChange).not.toHaveBeenCalled();
 
+        // Simulate blur (lose focus) event
+        fireEvent.blur(editor, { target: { value: 'New content' } });
         expect(defaultProps.onNoteDescriptionChange).toHaveBeenCalled();
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
     dependencies:
       '@dream-aim-deliver/dad-cats':
         specifier: ^0.9.9
-        version: 0.9.9(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+        version: 0.9.9(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       zod:
         specifier: ^3.24.1
         version: 3.24.1
@@ -384,7 +384,7 @@ importers:
         version: 2.5.5
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+        version: 2.1.8(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       zod:
         specifier: ^3.24.1
         version: 3.24.1
@@ -3155,6 +3155,9 @@ packages:
 
   '@types/node@18.16.9':
     resolution: {integrity: sha512-IeB32oIV4oGArLrd7znD2rkHQ6EDCM+2Sr76dJnrHwv9OHBTTM6nuDLK9bmikXzPa0ZlWMWtRGo/Uw4mrzQedA==}
+
+  '@types/node@22.17.0':
+    resolution: {integrity: sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -8470,6 +8473,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -9875,6 +9881,33 @@ snapshots:
       deep-equal-js: 0.2.2
       pino: 9.7.0
       vitest: 3.0.9(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@types/node'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - debug
+      - happy-dom
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  '@dream-aim-deliver/dad-cats@0.9.9(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)':
+    dependencies:
+      axios: 1.7.9
+      axios-retry: 4.5.0(axios@1.7.9)
+      deep-equal-js: 0.2.2
+      pino: 9.7.0
+      vitest: 3.0.9(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       zod: 3.24.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -12639,6 +12672,11 @@ snapshots:
 
   '@types/node@18.16.9': {}
 
+  '@types/node@22.17.0':
+    dependencies:
+      undici-types: 6.21.0
+    optional: true
+
   '@types/parse-json@4.0.2': {}
 
   '@types/qs@6.9.17': {}
@@ -12919,6 +12957,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.11(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
 
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.14
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+
   '@vitest/mocker@3.0.9(vite@5.4.11(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.0.9
@@ -12926,6 +12972,14 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 5.4.11(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+
+  '@vitest/mocker@3.0.9(vite@5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0))':
+    dependencies:
+      '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -12986,7 +13040,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      vitest: 2.1.8(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -13726,7 +13780,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.2
+      loupe: 3.1.4
       pathval: 2.0.0
 
   chalk@2.4.2:
@@ -18875,6 +18929,9 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.0
 
+  undici-types@6.21.0:
+    optional: true
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -18974,6 +19031,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.8(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.0.9(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
@@ -18981,6 +19056,24 @@ snapshots:
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 5.4.11(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@3.0.9(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -19047,6 +19140,20 @@ snapshots:
       stylus: 0.64.0
       terser: 5.37.0
 
+  vite@5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.28.0
+    optionalDependencies:
+      '@types/node': 22.17.0
+      fsevents: 2.3.3
+      less: 4.1.3
+      lightningcss: 1.28.2
+      sass: 1.82.0
+      stylus: 0.64.0
+      terser: 5.37.0
+
   vitest@2.1.8(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
@@ -19084,6 +19191,43 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@2.1.8(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.3.7
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      vite-node: 2.1.8(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.17.0
+      '@vitest/ui': 2.1.8(vitest@2.1.8)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vitest@3.0.9(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 3.0.9
@@ -19108,6 +19252,43 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.16.9
+      '@vitest/ui': 2.1.8(vitest@2.1.8)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.0.9(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0):
+    dependencies:
+      '@vitest/expect': 3.0.9
+      '@vitest/mocker': 3.0.9(vite@5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.0.9
+      '@vitest/snapshot': 3.0.9
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 5.4.11(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      vite-node: 3.0.9(@types/node@22.17.0)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.17.0
       '@vitest/ui': 2.1.8(vitest@2.1.8)
       jsdom: 25.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
# Fix LinkEdit Component Type Issues and Improve UX

##  Issues Fixed

1. **Type Safety Issue**: `onImageChange` callback was incorrectly typed to accept `TFileMetadata` instead of `TFileUploadRequest`
2. **UX Bug**: "Add Link" button was showing when LinkEdit component was open, violating Figma design
3. **Logic Bug**: `!editingLinkIndex` condition incorrectly treated index `0` as falsy
4. **Upload Bug**: File uploads were automatically creating empty links in the array

## Changes Made

- Updated `onImageChange` interface to use `TFileUploadRequest` → `Promise<TFileMetadata>`
- Fixed semantic distinction between upload requests vs stored file metadata
- Updated all consuming components and stories to match new interface
- `Add Link Button`: Changed from `disabled` state to complete hiding during edit mode
 
fix #277
