### PR TITLE
Translations, Du-Form and Formal changes on lib/dictionaries and /pages

### DIFF
--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -106,9 +106,9 @@ export const DE: TDictionary = {
     },
     courseCard: {
       courseEmptyState: {
-        message: 'Du hast noch keine Angebote gekauft',
-        buttonText: 'Angebote kaufen',
-        message2: 'Keine verfügbaren Angebote',
+        message: 'Du hast noch keine Kurse gekauft',
+        buttonText: 'Kurse kaufen',
+        message2: 'Keine verfügbaren Kurse',
       },
       createdBy: 'Erstellt von',
       you: 'Du',
@@ -133,7 +133,7 @@ export const DE: TDictionary = {
       coachingIncluded: 'Coaching enthalten',
       packageCourseSelectorTitle: 'Kaufe das gesamte Paket oder wähle nur die Kurse aus, die du benötigst',
       packageCourseSelectorDescription: 'Mit diesem Paket kannst du nur bestimmte Kurse auswählen oder das gesamte Paket erwerben, um maximal zu sparen.',
-      packageCourseSelectorButton: 'Ausgewählte Angebote kaufen',
+      packageCourseSelectorButton: 'Ausgewählte Kurse kaufen',
       saveText: 'speichern',
     },
     reviewModal: {
@@ -417,20 +417,20 @@ export const DE: TDictionary = {
       fileUploadFailedText: "Datei-Upload fehlgeschlagen",
       uploadImage: {
         choseImages: "Bilder auswählen",
-        description: "oder Bilder per Drag & Drop reinziehen",
+        description: "oder Bilder per Drag & Drop hierher ziehen",
       },
       uploadFile: {
         choseFiles: "Dateien auswählen",
-        description: "oder Dateien per Drag & Drop reinziehen",
+        description: "oder Dateien per Drag & Drop hierher ziehen",
       },
       uploadVideo: {
         choseVideos: "Videos auswählen",
-        description: "oder Videos per Drag & Drop reinziehen",
+        description: "oder Videos per Drag & Drop hierher ziehen",
 
       },
     },
     formRenderer: {
-      title: 'Bedarfsanalyse',
+      title: 'Leistungsbewertung vor dem Kurs',
       alertText: 'Sobald du deine Antwort abgeschickt hast, kannst du keine Änderungen mehr vornehmen. Bitte überprüfe sie daher sorgfältig. Das Ausfüllen dieses Formulars ist erforderlich, um mit dem Kurs beginnen zu können.',
       submitText: 'Antwort senden',
       requiredText: 'Erforderlich',
@@ -489,10 +489,10 @@ export const DE: TDictionary = {
       coachingSessionFilter: 'Coaching-Sitzig',
       minimumCoachingSessionsPlaceholder: 'z.B. 5',
       maximumCoachingSessionsPlaceholder: 'z.B. 50',
-      coursesBoughtFilter: 'Angebot gekauft',
+      coursesBoughtFilter: 'Kurs gekauft',
       minimumCoursesBoughtPlaceholder: 'z.B. 1',
       maximumCoursesBoughtPlaceholder: 'z.B. 20',
-      coursesCreatedFilter: 'Angebot erstellt',
+      coursesCreatedFilter: 'Kurs erstellt',
       minimumCoursesCreatedPlaceholder: 'z.B. 0',
       maximumCoursesCreatedPlaceholder: 'z.B. 10',
       lastAccessFilter: 'Letzter Zugriff',

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -324,7 +324,7 @@ export const DE: TDictionary = {
     },
     sideMenu: {
       studentText: 'Studierende',
-      coachText: 'Trainer',
+      coachText: 'Coach',
       courseCreatorText: 'Kurs-Creator',
     },
     coachingSessionCard: {
@@ -333,7 +333,7 @@ export const DE: TDictionary = {
       courseText: 'Kurs',
       groupText: 'Gruppe',
       joinMeetingText: 'Sitzung beitreten',
-      studentText: 'Studentin',
+      studentText: 'Studierende',
       hoursLeftToEditText: 'Stunden übrig, um das Ereignis zu bearbeiten',
       rescheduleText: 'Umbuchen',
       cancelText: 'Stornieren',
@@ -1068,7 +1068,7 @@ export const DE: TDictionary = {
         assessment: "Vorkurs-Formular",
         preview: "Kurs-Vorschau",
         students: "Studenten",
-        coaches: "Coaches",
+        coaches: "Coach",
         groups: "Gruppen",
       },
     },

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -106,9 +106,9 @@ export const DE: TDictionary = {
     },
     courseCard: {
       courseEmptyState: {
-        message: 'Du hast noch keine Kurse gekauft',
-        buttonText: 'Kurse kaufen',
-        message2: 'Keine verfügbaren Kurse',
+        message: 'Du hast noch keine Angebote gekauft',
+        buttonText: 'Angebote kaufen',
+        message2: 'Keine verfügbaren Angebote',
       },
       createdBy: 'Erstellt von',
       you: 'Du',
@@ -133,7 +133,7 @@ export const DE: TDictionary = {
       coachingIncluded: 'Coaching enthalten',
       packageCourseSelectorTitle: 'Kaufe das gesamte Paket oder wähle nur die Kurse aus, die du benötigst',
       packageCourseSelectorDescription: 'Mit diesem Paket kannst du nur bestimmte Kurse auswählen oder das gesamte Paket erwerben, um maximal zu sparen.',
-      packageCourseSelectorButton: 'Ausgewählte Kurse kaufen',
+      packageCourseSelectorButton: 'Ausgewählte Angebote kaufen',
       saveText: 'speichern',
     },
     reviewModal: {
@@ -430,7 +430,7 @@ export const DE: TDictionary = {
       },
     },
     formRenderer: {
-      title: 'Leistungsbewertung vor dem Kurs',
+      title: 'Bedarfsanalyse',
       alertText: 'Sobald du deine Antwort abgeschickt hast, kannst du keine Änderungen mehr vornehmen. Bitte überprüfe sie daher sorgfältig. Das Ausfüllen dieses Formulars ist erforderlich, um mit dem Kurs beginnen zu können.',
       submitText: 'Antwort senden',
       requiredText: 'Erforderlich',
@@ -489,10 +489,10 @@ export const DE: TDictionary = {
       coachingSessionFilter: 'Coaching-Sitzig',
       minimumCoachingSessionsPlaceholder: 'z.B. 5',
       maximumCoachingSessionsPlaceholder: 'z.B. 50',
-      coursesBoughtFilter: 'Kurs gekauft',
+      coursesBoughtFilter: 'Angebot gekauft',
       minimumCoursesBoughtPlaceholder: 'z.B. 1',
       maximumCoursesBoughtPlaceholder: 'z.B. 20',
-      coursesCreatedFilter: 'Kurs erstellt',
+      coursesCreatedFilter: 'Angebot erstellt',
       minimumCoursesCreatedPlaceholder: 'z.B. 0',
       maximumCoursesCreatedPlaceholder: 'z.B. 10',
       lastAccessFilter: 'Letzter Zugriff',

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -417,15 +417,15 @@ export const DE: TDictionary = {
       fileUploadFailedText: "Datei-Upload fehlgeschlagen",
       uploadImage: {
         choseImages: "Bilder auswählen",
-        description: "oder Bilder per Drag & Drop hierher ziehen",
+        description: "oder Bilder per Drag & Drop reinziehen",
       },
       uploadFile: {
         choseFiles: "Dateien auswählen",
-        description: "oder Dateien per Drag & Drop hierher ziehen",
+        description: "oder Dateien per Drag & Drop reinziehen",
       },
       uploadVideo: {
         choseVideos: "Videos auswählen",
-        description: "oder Videos per Drag & Drop hierher ziehen",
+        description: "oder Videos per Drag & Drop reinziehen",
 
       },
     },

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -17,7 +17,7 @@ export const EN: TDictionary = {
     },
     defaultError: {
       title: 'Something went wrong',
-      description: 'A critical error occurred. Please try reloading the page. If the issue persists, contact us at{contactEmail}.',
+      description: 'A critical error occurred. Please try reloading the page. If the issue persists, contact us at {contactEmail}.',
       retry: 'Retry',
     },
     defaultNotFound: {

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -21,7 +21,7 @@ export const EN: TDictionary = {
       retry: 'Retry',
     },
     defaultNotFound: {
-      title: 'Not Found',
+      title: 'Not found',
       description: 'Sorry, the page you’re looking for doesn’t exist or may have been moved.',
       retry: 'Retry',
       goBack: 'Go to Homepage',

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -17,11 +17,11 @@ export const EN: TDictionary = {
     },
     defaultError: {
       title: 'Something went wrong',
-      description: 'A critical error occurred. Please try reloading the page. If the issue persists, contact us at {contactEmail}.',
+      description: 'A critical error occurred. Please try reloading the page. If the issue persists, contact us at{contactEmail}.',
       retry: 'Retry',
     },
     defaultNotFound: {
-      title: 'Not found',
+      title: 'Not Found',
       description: 'Sorry, the page you’re looking for doesn’t exist or may have been moved.',
       retry: 'Retry',
       goBack: 'Go to Homepage',

--- a/packages/translations/src/lib/pages/coaching/coaching-de.ts
+++ b/packages/translations/src/lib/pages/coaching/coaching-de.ts
@@ -2,5 +2,5 @@ import { TDictionary } from '../../dictionaries/base';
 
 export const Coaching_DE: TDictionary['pages']['coaching'] = {
   filterByTopic: 'Suche nach Thema / Fähigkeit',
-  chooseCategory: 'Was ist Ihr Ziel?',
+  chooseCategory: 'Was ist dein Ziel?',
 };

--- a/packages/translations/src/lib/pages/offers/offers-de.ts
+++ b/packages/translations/src/lib/pages/offers/offers-de.ts
@@ -2,22 +2,22 @@ import { TDictionary } from '../../dictionaries/base';
 
 export const Offers_DE: TDictionary['pages']['offers'] = {
   filterByTopic: 'Nach Thema filtern',
-  chooseCategory: 'Was ist Ihr Ziel?',
-  ourCourses: 'Unsere Kurse',
+  chooseCategory: 'Was ist dein Ziel?',
+  ourCourses: 'Unsere Angebote',
   ourPackages: 'Unsere Pakete',
   coachingIncluded: 'Coaching inklusive',
-  coachingOnDemand: 'Coaching auf Abruf',
-  haveNotFound: 'Haben Sie nicht gefunden, wonach Sie suchen?',
+  coachingOnDemand: 'Coaching bei Bedarf',
+  haveNotFound: 'Noch nicht gefunden, wonach du suchst?',
   coursesNotFound: {
-    title: "Keine Kurse gefunden",
-    description: "Es konnten keine Kurse gefunden werden, die Ihren Kriterien entsprechen. Bitte passen Sie Ihre Filter an oder schauen Sie später noch einmal vorbei.",
+    title: "Keine Angebote gefunden",
+    description: "Wir konnten keine passenden Angebote finden. Passe deine Filter an – oder sag uns, was dir fehlt. Wir freunen uns auf dein Feedback.",
   },
   coachesNotFound: {
     title: "Keine Coaches gefunden",
-    description: "Es konnten keine Coaches gefunden werden, die Ihren Kriterien entsprechen. Bitte passen Sie Ihre Filter an oder schauen Sie später noch einmal vorbei.",
+    description: "Leider keine passenden Coaches gefunden. Probiere andere Filter – oder melde dich bei uns und sag, welche Unterstützung du suchst.",
   },
   packagesNotFound: {
     title: "Keine Pakete gefunden",
-    description: "Bitte schauen Sie später noch einmal vorbei.",
+    description: "Momentan sind keine Pakete verfügbar. Schau bald wieder vorbei – oder teile uns mit, welche Angebote dich interessieren würden.",
   }
 };

--- a/packages/translations/src/lib/pages/offers/offers-en.ts
+++ b/packages/translations/src/lib/pages/offers/offers-en.ts
@@ -1,23 +1,23 @@
 import { TDictionary } from "../../dictionaries/base";
 
 export const Offers_EN: TDictionary["pages"]["offers"] = {
-  filterByTopic: "Filter by Topic",
+  filterByTopic: "Filter by topic",
   chooseCategory: "What's your goal?",
-  ourCourses: "Our Courses",
+  ourCourses: "Our Offers",
   ourPackages: "Our Packages",
   coachingIncluded: "Coaching Included",
   coachingOnDemand: "Coaching on demand",
   haveNotFound: "Haven't found what you're looking for?",
   coursesNotFound: {
-    title: "No courses found",
-    description: "Couldn't find any courses matching your criteria. Please try adjusting your filters or check back later.",
+    title: "No offers found",
+    description: "We couldn’t find any offers matching your criteria. Try adjusting your filters – or tell us what you’d like to see. We’d love your feedback!",
   },
   coachesNotFound: {
     title: "No coaches found",
-    description: "Couldn't find any coaches matching your criteria. Please try adjusting your filters or check back later.",
+    description: "No coaches matched your criteria. Try different filters – or get in touch and let us know what kind of support you’re looking for.",
   },
   packagesNotFound: {
     title: "No packages found",
-    description: "Please check back later.",
+    description: "There are currently no packages available. Please check back soon – or share with us what kind of offers you’d like.",
   }
 }

--- a/packages/translations/src/lib/pages/sso/sso-de.ts
+++ b/packages/translations/src/lib/pages/sso/sso-de.ts
@@ -3,7 +3,7 @@ import { TDictionary } from "../../dictionaries/base";
 export const SSO_DE: TDictionary["pages"]["sso"] = {
     termsAndConditions: {
         title: 'Allgemeine Geschäftsbedingungen',
-        content: 'Bitte lesen Sie die Plattformrichtlinie sorgfältig durch, bevor Sie fortfahren.',
+        content: 'Bitte lies dir unsere Plattformrichtlinien aufmerksam durch, bevor du fortfährst.',
         confirmationText: 'Ich habe die Allgemeinen Geschäftsbedingungen gelesen und akzeptiere sie.'
     }
 };


### PR DESCRIPTION
This PR includes changes to almost all texts I found in
packages/translations/src/lib/dictionaries
and
packages/translations/src/lib/pages.

What’s still missing are the adjustments to home-de.ts. As soon as I know exactly which page this is and what it roughly looks like, I can make the changes. Still waiting for feedback from Luis.

