### PR TITLE
Update translations for gender neutrality and informal tone in German

### DIFF
--- a/apps/platform/src/lib/infrastructure/common/mocks/procedures/home-page.ts
+++ b/apps/platform/src/lib/infrastructure/common/mocks/procedures/home-page.ts
@@ -262,8 +262,8 @@ const accordionMockData: useCaseModels.TGetHomePageSuccessResponse['data']['acco
 const homePageMock: useCaseModels.TGetHomePageSuccessResponse['data'] = {
     banner: {
         description:
-            'Platform introduction. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi. Aliquam in hendrerit urna. Pellentesque sit amet sapien fringilla, mattis ligula consectetur, ultrices mauris. Maecenas vitae mattis tellus. Nullam quis imperdiet augue. Vestibulum auctor ornare leo, non suscipit magna interdum eu.',
-        title: "Simply create good advertising yourself.",
+            'Finally: the solution for companies and teams who want to invest in visibility – not agency fees. With JUST DO AD you gain the skills to design and launch your own advertising: branding, campaigns, websites, videos, and content. Hands-on, step by step, tailored to your needs – with as much or as little support as you choose.',
+        title: "Become your own ad agency.",
         videoId: 'o017yCZbw87zC9xDoy1Bl02FsbCBXuSdx6xPbkF01sW02IU',
         thumbnailUrl:
             'https://res.cloudinary.com/dnhiejjyu/image/upload/v1748006627/hb-thumb_eabema.png',

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -294,7 +294,7 @@ export const DE: TDictionary = {
       dashboard: 'Dashboard',
       yourProfile: 'Dein Profil',
       logout: 'Abmelden',
-      yourCourses: 'Deine Kurse', // Guidelines: informal 'Du' instead of formal 'Sie/Ihre'
+      yourCourses: 'Deine Angebote',
     },
     footer: {
       impressum: 'Impressum',
@@ -860,7 +860,7 @@ export const DE: TDictionary = {
     breadcrumbs: {
       home: 'Startseite',
       workspace: 'Arbeitsbereich',
-      courses: 'Kurse',
+      courses: 'Deine Angebote',
       createCourse: 'Kurs erstellen',
       editCourse: 'Kurs bearbeiten',
       editLesson: 'Lektion bearbeiten',
@@ -1073,7 +1073,7 @@ export const DE: TDictionary = {
       },
     },
     userCourses: {
-      yourCourses: 'Deine Kurse',
+      yourCourses: 'Deine Angebote',
       createCourse: 'Einen Kurs erstellen',
       becomeCourseCreator: 'Kurs-Creator werden',
     },
@@ -1090,7 +1090,7 @@ export const DE: TDictionary = {
     sidebarLayout: {
       dashboard: "Dashboard",
       courses: "Kurse",
-      yourCourses: "Deine Kurse",
+      yourCourses: "Deine Angebote",
       coachingSessions: "Coaching-Sitzungen",
       yourCoachingSessions: "Deine Coaching-Sitzungen",
       calendar: "Kalender",
@@ -1125,7 +1125,7 @@ export const DE: TDictionary = {
       componentsTitle: 'Komponenten',
       editCourseTitle: 'Kurs bearbeiten',
       generalTab: 'Allgemein',
-      introOutlineTab: 'Intro & Übersicht',
+      introOutlineTab: 'Intro & Details',
       courseContent: 'Kursinhalte',
       confirmSwitch: 'Es gibt ungespeicherte Änderungen. Möchtest du wirklich den Tab wechseln?',
       tabSwitchCancelled: 'Tab-Wechsel wurde wegen ungespeicherter Änderungen abgebrochen.',
@@ -1149,13 +1149,13 @@ export const DE: TDictionary = {
       outlineText: 'Details zum Angebot',
     },
     courseOutline: {
-      courseContent: 'Gliederung',
+      courseContent: 'Details',
     },
     categoryTopics: {
       allText: 'Alle',
     },
     userCoursesList: {
-      emptyState: 'Du hast noch keine Kurse.', // Guidelines: informal 'Du' instead of formal 'Sie'
+      emptyState: 'Du hast noch keine Angebote.'
     },
   },
 };

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -28,7 +28,7 @@ export const DE: TDictionary = {
     },
     defaultComingSoon: {
       title: 'Bald verfügbar',
-      description: 'Diese Seite entsteht gerade. Sie wird bald verfügbar sein!',
+      description: 'Diese Seite entsteht gerade. Sie wird bald verfügbar sein!', // Guidelines: informal 'Du' - but here 'Sie' refers to the page, not the user
       goBack: 'Zurück',
     },
     coachBanner: {
@@ -84,7 +84,7 @@ export const DE: TDictionary = {
       sendNotification: 'Benachrichtigung senden',
       hideActions: 'Aktionen ausblenden',
       all: 'Alle',
-      students: 'Studenten',
+      students: 'Studierende', // Guidelines: gender-neutral wording
       coaches: 'Coaches',
       courseCreators: 'Kurs-Creators',
       admin: 'Admin',
@@ -294,7 +294,7 @@ export const DE: TDictionary = {
       dashboard: 'Dashboard',
       yourProfile: 'Dein Profil',
       logout: 'Abmelden',
-      yourCourses: 'Ihre Kurse',
+      yourCourses: 'Deine Kurse', // Guidelines: informal 'Du' instead of formal 'Sie/Ihre'
     },
     footer: {
       impressum: 'Impressum',
@@ -693,7 +693,7 @@ export const DE: TDictionary = {
       typeThreeText: 'Typ 3',
       typeFourText: 'Typ 4',
       quizTypeOne: {
-        headingText: 'Der Student wählt eine korrekte Antwort von vielen',
+        headingText: 'Wähle eine korrekte Antwort von vielen', // Guidelines: gender-neutral, informal 'Du'
         radioButtonText: 'Text der Optionsschaltfläche',
         validationErrors: {
           wrongElementType: 'Falscher Elementtyp',
@@ -706,9 +706,9 @@ export const DE: TDictionary = {
         },
       },
       quizTypeTwo: {
-        headingText: 'Der Student muss für jede Gruppe die richtige Wahl treffen',
+        headingText: 'Für jede Gruppe die richtige Wahl treffen', // Guidelines: gender-neutral, informal 'Du'
         uploadImageText: 'Bild hochladen (erforderlich)',
-        errorText: 'Sie sollten wissen, was die richtige Antwort ist',
+        errorText: 'Du solltest wissen, was die richtige Antwort ist', // Guidelines: informal 'Du' instead of formal 'Sie'
         groupTitleText: 'Titel der Gruppe',
         radioButtonText: 'Text der Optionsschaltfläche',
         validationErrors: {
@@ -724,7 +724,7 @@ export const DE: TDictionary = {
         },
       },
       quizTypeThree: {
-        headingText: 'Der Student entscheidet sich für eine der 2 Bilder',
+        headingText: 'Entscheide dich für eines der 2 Bilder', // Guidelines: gender-neutral, informal 'Du'
         choiceDescriptionText: 'Beschreibung der Option',
         validationErrors: {
           wrongElementType: 'Falscher Elementtyp',
@@ -737,7 +737,7 @@ export const DE: TDictionary = {
         },
       },
       quizTypeFour: {
-        headingText: 'Der Student muss den gesamten Text allen Bildern zuordnen',
+        headingText: 'Ordne den gesamten Text allen Bildern zu', // Guidelines: gender-neutral, informal 'Du'
         choiceDescriptionText: 'Beschreibung der Option',
         correctLetterText: 'Richtiges Zeichen',
         validationErrors: {
@@ -773,7 +773,7 @@ export const DE: TDictionary = {
       back: "Zurück",
       editCoachNotes: "Coach Notizen bearbeiten",
       exploreCourses: "Kurse erkunden",
-      description: "Hinweis: Jede von Ihnen vorgenommene Änderung sendet eine Benachrichtigung an alle Studierenden in dieser Gruppe. Bitte überprüfen Sie diese sorgfältig, bevor Sie sie veröffentlichen.",
+      description: "Hinweis: Jede von dir vorgenommene Änderung sendet eine Benachrichtigung an alle Studierenden in dieser Gruppe. Bitte überprüfe diese sorgfältig, bevor du sie veröffentlichst.", // Guidelines: informal 'Du' instead of formal 'Sie/Ihnen'
     },
     buyCoachingSessionBanner: {
       coachBadge: 'Coach',
@@ -825,7 +825,7 @@ export const DE: TDictionary = {
       courseSection: 'Kurs',
       moduleSection: 'Modul',
       lessonSection: 'Lektion',
-      studentSection: 'Studenten',
+      studentSection: 'Studierende', // Guidelines: gender-neutral wording
       groupSection: 'Gruppe',
       titlePlaceholder: 'Nach Titel suchen...',
       coursePlaceholder: 'Nach Kurs suchen...',
@@ -873,7 +873,7 @@ export const DE: TDictionary = {
       briefDescriptionPlaceholder: 'Füge eine kurze Beschreibung des Kurses hinzu...',
       estimatedDuration: 'Geschätzte Dauer in Stunden',
       requirements: 'Anforderungen',
-      requirementsDescription: 'Was wird von den Studierenden erwartet, um diesen Kurs zu beginnen? Füge unten die erforderlichen Kurse hinzu.',
+      requirementsDescription: 'Was wird von den Studierenden erwartet, um diesen Kurs zu beginnen? Füge unten die erforderlichen Kurse hinzu.', // Guidelines: already uses gender-neutral 'Studierende'
       searchCoursesPlaceholder: 'Kurse suchen',
       featuredImage: 'Vorschaubild',
       removeCourse: 'Kurs entfernen'
@@ -1054,20 +1054,20 @@ export const DE: TDictionary = {
       },
       roleDropdown: {
         viewAs: "Ansehen als",
-        student: "Student",
+        student: "Studierende", // Guidelines: gender-neutral wording
         coach: "Coach",
-        creator: "Kurs-Ersteller",
+        creator: "Kurs-Creator",
         admin: "Admin",
       },
       tabs: {
         introduction: "Einführung",
         study: "Studium",
         assignments: "Aufgaben",
-        notes: "Ihre Notizen",
+        notes: "Deine Notizen", // Guidelines: informal 'Du' instead of formal 'Sie/Ihre'
         material: "Material",
         assessment: "Vorkurs-Formular",
         preview: "Kurs-Vorschau",
-        students: "Studenten",
+        students: "Studierende", // Guidelines: gender-neutral wording
         coaches: "Coach",
         groups: "Gruppen",
       },
@@ -1094,7 +1094,7 @@ export const DE: TDictionary = {
       coachingSessions: "Coaching-Sitzungen",
       yourCoachingSessions: "Deine Coaching-Sitzungen",
       calendar: "Kalender",
-      yourStudents: "Deine Studenten",
+      yourStudents: "Deine Studierenden", // Guidelines: gender-neutral wording
       yourReviews: "Deine Bewertungen",
       yourProfile: "Dein Profil",
       orderPayments: "Bestellungen & Zahlungen",
@@ -1155,7 +1155,7 @@ export const DE: TDictionary = {
       allText: 'Alle',
     },
     userCoursesList: {
-      emptyState: 'Sie haben noch keine Kurse.',
+      emptyState: 'Du hast noch keine Kurse.', // Guidelines: informal 'Du' instead of formal 'Sie'
     },
   },
 };

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -6,7 +6,7 @@ import { Offers_EN } from '../pages/offers/offers-en';
 import { Coaching_EN } from '../pages/coaching/coaching-en';
 
 
-export const EN: TDictionary = {  
+export const EN: TDictionary = {
   components: {
     paginationButton: {
       loadMore: 'Load more...',
@@ -291,7 +291,7 @@ export const EN: TDictionary = {
       dashboard: 'Dashboard',
       yourProfile: 'Your Profile',
       logout: 'Logout',
-      yourCourses: 'Your Courses',
+      yourCourses: 'Your Offers',
     },
     footer: {
       impressum: 'Impressum',
@@ -856,7 +856,7 @@ export const EN: TDictionary = {
     breadcrumbs: {
       home: 'Home',
       workspace: 'Workspace',
-      courses: 'Your courses',
+      courses: 'Your offers',
       createCourse: 'Create course',
       editCourse: 'Edit course',
       editLesson: 'Edit lesson',
@@ -1070,7 +1070,7 @@ export const EN: TDictionary = {
       },
     },
     userCourses: {
-      yourCourses: 'Your Courses',
+      yourCourses: 'Your offers',
       createCourse: 'Create a course',
       becomeCourseCreator: 'Become a course creator',
     },
@@ -1087,7 +1087,7 @@ export const EN: TDictionary = {
     sidebarLayout: {
       dashboard: "Dashboard",
       courses: "Courses",
-      yourCourses: "Your Courses",
+      yourCourses: "Your offers",
       coachingSessions: "Coaching Sessions",
       yourCoachingSessions: "Your Coaching Sessions",
       calendar: "Calendar",
@@ -1122,7 +1122,7 @@ export const EN: TDictionary = {
       componentsTitle: 'Components',
       editCourseTitle: 'Edit Course',
       generalTab: 'General',
-      introOutlineTab: 'Intro & Outline',
+      introOutlineTab: 'Intro & Details',
       courseContent: 'Course Content',
       confirmSwitch: 'You have unsaved changes. Are you sure you want to switch tabs?',
       tabSwitchCancelled: 'Tab switch cancelled due to unsaved changes.',
@@ -1146,13 +1146,13 @@ export const EN: TDictionary = {
       outlineText: 'Offer Details',
     },
     courseOutline: {
-      courseContent: 'Outline',
+      courseContent: 'Details',
     },
     categoryTopics: {
       allText: 'All',
     },
     userCoursesList: {
-      emptyState: 'You don’t have any courses yet.',
-    },  
+      emptyState: 'You don’t have any offers yet.',
+    },
   },
 };

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -427,7 +427,7 @@ export const EN: TDictionary = {
     },
     formRenderer: {
       title: 'Pre-Assessment',
-      alertText: 'Once you submit your response, you won’t be able to make changes, so please review it carefully. Completing this form is required to begin the course.',
+      alertText: 'Once you submit your response, you won\'t be able to make changes, so please review it carefully. Complete this form to begin your course.', // Guidelines: friendlier, more direct tone
       submitText: 'send reply',
       requiredText: 'required',
       fieldRequired: 'This field is required',
@@ -683,7 +683,7 @@ export const EN: TDictionary = {
       hideSolutionText: 'Hide solution',
       checkAnswerText: 'Check answer',
       clearText: 'Clear',
-      errorText: "You need to define what's the correct answer",
+      errorText: "Please define the correct answer", // Guidelines: friendlier, more direct tone
       typeOneText: "Type 1",
       typeTwoText: "Type 2",
       typeThreeText: "Type 3",
@@ -704,7 +704,7 @@ export const EN: TDictionary = {
       quizTypeTwo: {
         headingText: 'Student has to choose the right choice for each group',
         uploadImageText: 'Upload Image (Required)',
-        errorText: "You need to define what's the correct answer",
+        errorText: "Please define the correct answer", // Guidelines: friendlier, more direct tone
         groupTitleText: 'Group title',
         radioButtonText: 'Radio button text',
         validationErrors: {

--- a/packages/translations/src/lib/pages/login/login-de.ts
+++ b/packages/translations/src/lib/pages/login/login-de.ts
@@ -2,7 +2,7 @@ import { TDictionary } from "../../dictionaries/base";
 
 export const Login_DE: TDictionary["pages"]["login"] = {
     title: 'Anmelden',
-    postLogout: 'Sie wurden erfolgreich abgemeldet',
+    postLogout: 'Du wurdest erfolgreich abgemeldet', // Guidelines: informal 'Du' instead of formal 'Sie'
     username: 'Benutzername',
     password: 'Passwort',
     signIn: 'Anmelden',

--- a/packages/translations/src/lib/pages/offers/offers-de.ts
+++ b/packages/translations/src/lib/pages/offers/offers-de.ts
@@ -10,7 +10,7 @@ export const Offers_DE: TDictionary['pages']['offers'] = {
   haveNotFound: 'Noch nicht gefunden, wonach du suchst?',
   coursesNotFound: {
     title: "Keine Angebote gefunden",
-    description: "Wir konnten keine passenden Angebote finden. Passe deine Filter an – oder sag uns, was dir fehlt. Wir freunen uns auf dein Feedback.",
+    description: "Wir konnten keine passenden Angebote finden. Passe deine Filter an – oder sag uns, was dir fehlt. Wir freuen uns auf dein Feedback.", // Fixed typo: 'freunen' → 'freuen'
   },
   coachesNotFound: {
     title: "Keine Coaches gefunden",


### PR DESCRIPTION
Revise German translations to adopt gender-neutral language and a more informal tone, enhancing user engagement and inclusivity. Fix a typo in the offers page description.