### PR TITLE
Add schemas for student coaching sessions and notifications

### DIFF
--- a/packages/models/src/usecase-models/common.ts
+++ b/packages/models/src/usecase-models/common.ts
@@ -471,3 +471,9 @@ export const LessonComponentRequestSchema = z.discriminatedUnion('type', [
 
 export type TAssessmentComponentRequest = z.infer<typeof AssessmentComponentRequestSchema>;
 export type TLessonComponentRequest = z.infer<typeof LessonComponentRequestSchema>;
+
+
+export const ScheduledCoachingSessionStatusSchema = z.enum(['scheduled', 'completed', 'canceled']);
+
+export type TScheduledCoachingSessionStatus = z.infer<typeof ScheduledCoachingSessionStatusSchema>;
+

--- a/packages/models/src/usecase-models/common.ts
+++ b/packages/models/src/usecase-models/common.ts
@@ -477,3 +477,19 @@ export const ScheduledCoachingSessionStatusSchema = z.enum(['scheduled', 'comple
 
 export type TScheduledCoachingSessionStatus = z.infer<typeof ScheduledCoachingSessionStatusSchema>;
 
+export const ActionSchema = z.object({
+    title: z.string(),
+    url: z.string(),
+});
+
+export type TAction = z.infer<typeof ActionSchema>;
+
+export const NotificationSchema = z.object({
+    message: z.string(),
+    action: ActionSchema,
+    timestamp: z.string().datetime({ offset: true }),
+    isRead: z.boolean(),
+});
+
+export type TNotification = z.infer<typeof NotificationSchema>;
+

--- a/packages/models/src/usecase-models/list-notifications-usecase-models.ts
+++ b/packages/models/src/usecase-models/list-notifications-usecase-models.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import {
+    BaseErrorDiscriminatedUnionSchemaFactory,
+    BaseStatusDiscriminatedUnionSchemaFactory,
+    BaseSuccessSchemaFactory
+} from '@dream-aim-deliver/dad-cats';
+import { DefaultPaginationSchema } from '../utils/pagination';
+import { NotificationSchema } from './common';
+
+export const ListNotificationsRequestSchema = DefaultPaginationSchema.extend({
+    userId: z.number(),
+});
+export type TListNotificationsRequest = z.infer<typeof ListNotificationsRequestSchema>;
+
+export const ListNotificationsSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({
+    notifications: NotificationSchema.extend({
+        id: z.number(),
+    }).array(),
+}));
+
+export type TListNotificationsSuccessResponse = z.infer<typeof ListNotificationsSuccessResponseSchema>;
+
+const ListNotificationsUseCaseErrorResponseSchema = BaseErrorDiscriminatedUnionSchemaFactory({});
+export type TListNotificationsUseCaseErrorResponse = z.infer<typeof ListNotificationsUseCaseErrorResponseSchema>;
+
+export const ListNotificationsUseCaseResponseSchema = BaseStatusDiscriminatedUnionSchemaFactory([
+    ListNotificationsSuccessResponseSchema,
+    ListNotificationsUseCaseErrorResponseSchema,
+]);
+
+export type TListNotificationsUseCaseResponse = z.infer<typeof ListNotificationsUseCaseResponseSchema>;

--- a/packages/models/src/usecase-models/list-student-coaching-sessions-usecase-models.ts
+++ b/packages/models/src/usecase-models/list-student-coaching-sessions-usecase-models.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import {
+    BaseErrorDiscriminatedUnionSchemaFactory,
+    BaseStatusDiscriminatedUnionSchemaFactory,
+    BaseSuccessSchemaFactory
+} from '@dream-aim-deliver/dad-cats';
+import { DefaultPaginationSchema } from '../utils/pagination';
+import { ScheduledCoachingSessionStatusSchema } from './common';
+
+export const ListStudentCoachingSessionsRequestSchema = DefaultPaginationSchema.extend({
+    studentId: z.number(),
+});
+export type TListStudentCoachingSessionsRequest = z.infer<typeof ListStudentCoachingSessionsRequestSchema>;
+
+const CoachingSessionSchema = z.object({
+    id: z.number(),
+    coachingOfferingTitle: z.string(),
+    coachingOfferingDuration: z.number(),  // minutes
+    status: ScheduledCoachingSessionStatusSchema,
+    startTime: z.string(),
+    endTime: z.string(),
+    coach: z.object({
+        name: z.string().nullable(),
+        surname: z.string().nullable(),
+        username: z.string(),
+        avatarUrl: z.string().nullable(),
+    }),
+    course: z.object({
+        id: z.number(),
+        title: z.string(),
+        slug: z.string(),
+    }).optional().nullable(),
+    meetingUrl: z.string().nullable(),
+});
+
+
+export const ListStudentCoachingSessionsSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({
+    sessions: CoachingSessionSchema.array(),
+}));
+
+export type TListStudentCoachingSessionsSuccessResponse = z.infer<typeof ListStudentCoachingSessionsSuccessResponseSchema>;
+
+const ListStudentCoachingSessionsUseCaseErrorResponseSchema = BaseErrorDiscriminatedUnionSchemaFactory({});
+export type TListStudentCoachingSessionsUseCaseErrorResponse = z.infer<typeof ListStudentCoachingSessionsUseCaseErrorResponseSchema>;
+
+export const ListStudentCoachingSessionsUseCaseResponseSchema = BaseStatusDiscriminatedUnionSchemaFactory([
+    ListStudentCoachingSessionsSuccessResponseSchema,
+    ListStudentCoachingSessionsUseCaseErrorResponseSchema,
+]);
+
+export type TListStudentCoachingSessionsUseCaseResponse = z.infer<typeof ListStudentCoachingSessionsUseCaseResponseSchema>;

--- a/packages/models/src/usecase-models/list-student-coaching-sessions-usecase-models.ts
+++ b/packages/models/src/usecase-models/list-student-coaching-sessions-usecase-models.ts
@@ -17,8 +17,8 @@ const CoachingSessionSchema = z.object({
     coachingOfferingTitle: z.string(),
     coachingOfferingDuration: z.number(),  // minutes
     status: ScheduledCoachingSessionStatusSchema,
-    startTime: z.string(),
-    endTime: z.string(),
+    startTime: z.string().datetime({ offset: true }),
+    endTime: z.string().datetime({ offset: true }),
     coach: z.object({
         name: z.string().nullable(),
         surname: z.string().nullable(),

--- a/packages/models/src/usecase-models/mark-notifications-as-read-usecase-models.ts
+++ b/packages/models/src/usecase-models/mark-notifications-as-read-usecase-models.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import {
+    BaseErrorDiscriminatedUnionSchemaFactory,
+    BaseStatusDiscriminatedUnionSchemaFactory,
+    BaseSuccessSchemaFactory
+} from '@dream-aim-deliver/dad-cats';
+import { NotificationSchema } from './common';
+
+export const MarkNotificationsAsReadRequestSchema = z.object({
+    notificationIds: z.array(z.number()),
+});
+export type TMarkNotificationsAsReadRequest = z.infer<typeof MarkNotificationsAsReadRequestSchema>;
+
+export const MarkNotificationsAsReadSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({
+    notifications: NotificationSchema.extend({
+        id: z.number(),
+    }).array(),
+}));
+
+export type TMarkNotificationsAsReadSuccessResponse = z.infer<typeof MarkNotificationsAsReadSuccessResponseSchema>;
+
+const MarkNotificationsAsReadUseCaseErrorResponseSchema = BaseErrorDiscriminatedUnionSchemaFactory({});
+export type TMarkNotificationsAsReadUseCaseErrorResponse = z.infer<typeof MarkNotificationsAsReadUseCaseErrorResponseSchema>;
+
+export const MarkNotificationsAsReadUseCaseResponseSchema = BaseStatusDiscriminatedUnionSchemaFactory([
+    MarkNotificationsAsReadSuccessResponseSchema,
+    MarkNotificationsAsReadUseCaseErrorResponseSchema,
+]);
+
+export type TMarkNotificationsAsReadUseCaseResponse = z.infer<typeof MarkNotificationsAsReadUseCaseResponseSchema>;


### PR DESCRIPTION
Introduce request and response schemas for listing student coaching sessions and notifications, along with error handling for marking notifications as read.