### PR TITLE
Implement schedule coaching session use case models

### DIFF
--- a/packages/models/src/usecase-models/schedule-coaching-session-usecase-models.ts
+++ b/packages/models/src/usecase-models/schedule-coaching-session-usecase-models.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import {
+    BaseErrorDiscriminatedUnionSchemaFactory,
+    BaseStatusDiscriminatedUnionSchemaFactory,
+    BaseSuccessSchemaFactory
+} from '@dream-aim-deliver/dad-cats';
+
+export const ScheduleCoachingSessionRequestSchema = z.object({
+    coachingSessionId: z.number(),
+});
+export type TScheduleCoachingSessionRequest = z.infer<typeof ScheduleCoachingSessionRequestSchema>;
+
+const ScheduledCoachingSessionSchema = z.object({
+    id: z.number(),
+    coachingOfferingTitle: z.string(),
+    coachingOfferingDuration: z.number(),  // minutes
+    status: z.literal('scheduled'),
+    startTime: z.string().datetime({ offset: true }),
+    endTime: z.string().datetime({ offset: true }),
+    student: z.object({
+        name: z.string().nullable(),
+        surname: z.string().nullable(),
+        username: z.string(),
+        avatarUrl: z.string().nullable(),
+    }),
+    course: z.object({
+        id: z.number(),
+        title: z.string(),
+        slug: z.string(),
+    }).optional().nullable(),
+    meetingUrl: z.string().nullable(),
+});
+
+export const ScheduleCoachingSessionSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({
+    coachingSession: ScheduledCoachingSessionSchema,
+}));
+
+export type TScheduleCoachingSessionSuccessResponse = z.infer<typeof ScheduleCoachingSessionSuccessResponseSchema>;
+
+const ScheduleCoachingSessionUseCaseErrorResponseSchema = BaseErrorDiscriminatedUnionSchemaFactory({});
+export type TScheduleCoachingSessionUseCaseErrorResponse = z.infer<typeof ScheduleCoachingSessionUseCaseErrorResponseSchema>;
+
+export const ScheduleCoachingSessionUseCaseResponseSchema = BaseStatusDiscriminatedUnionSchemaFactory([
+    ScheduleCoachingSessionSuccessResponseSchema,
+    ScheduleCoachingSessionUseCaseErrorResponseSchema,
+]);
+
+export type TScheduleCoachingSessionUseCaseResponse = z.infer<typeof ScheduleCoachingSessionUseCaseResponseSchema>;

--- a/packages/models/src/usecase-models/unschedule-coaching-session-usecase-models.ts
+++ b/packages/models/src/usecase-models/unschedule-coaching-session-usecase-models.ts
@@ -10,7 +10,16 @@ export const UnscheduleCoachingSessionRequestSchema = z.object({
 });
 export type TUnscheduleCoachingSessionRequest = z.infer<typeof UnscheduleCoachingSessionRequestSchema>;
 
-export const UnscheduleCoachingSessionSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({}));
+const UnscheduledCoachingSessionSchema = z.object({
+    id: z.number(),
+    coachingOfferingTitle: z.string(),
+    coachingOfferingDuration: z.number(),  // minutes
+    status: z.literal('unscheduled'),
+});
+
+export const UnscheduleCoachingSessionSuccessResponseSchema = BaseSuccessSchemaFactory(z.object({
+    coachingSession: UnscheduledCoachingSessionSchema,
+}));
 
 export type TUnscheduleCoachingSessionSuccessResponse = z.infer<typeof UnscheduleCoachingSessionSuccessResponseSchema>;
 


### PR DESCRIPTION
Introduce schemas for scheduling and unscheduling coaching sessions, including request and response types for both operations.