### PR TITLE
feat: enable server-side prefetching across all RSC components

### DIFF
--- a/apps/cms/src/app/[locale]/(wired-pages)/(platform-management)/platform/[platform_slug]/[platform_locale]/page.tsx
+++ b/apps/cms/src/app/[locale]/(wired-pages)/(platform-management)/platform/[platform_slug]/[platform_locale]/page.tsx
@@ -2,7 +2,7 @@
 import { Suspense } from 'react';
 import PlatformManagement from '../../../../../../../lib/infrastructure/client/pages/platform-management';
 import DefaultLoadingWrapper from '../../../../../../../lib/infrastructure/client/wrappers/default-loading';
-import { HydrateClient, getServerTRPC } from '../../../../../../../lib/infrastructure/server/config/trpc/cms-server';
+import { HydrateClient, getServerTRPC, prefetch } from '../../../../../../../lib/infrastructure/server/config/trpc/cms-server';
 
 export default async function Page({
     params: paramsPromise,
@@ -22,10 +22,10 @@ export default async function Page({
     const trpc = getServerTRPC(params);
 
     // Optional: Prefetch data for better performance
-    // await Promise.all([
-    //     prefetch(trpc.listTopics.queryOptions({})),
-    //     prefetch(trpc.listCategories.queryOptions({})),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.listTopics.queryOptions({})),
+        prefetch(trpc.listCategories.queryOptions({})),
+    ]);
 
     let tab = searchParams.tab;
 

--- a/apps/cms/src/lib/infrastructure/server/pages/course-rsc.tsx
+++ b/apps/cms/src/lib/infrastructure/server/pages/course-rsc.tsx
@@ -133,30 +133,31 @@ async function prefetchIntroductionData(
     slug: string,
     currentRole: string,
 ): Promise<void> {
+    const trpc = getServerTRPC();
     const promises = [
-        // prefetch(
-        //     trpc.getEnrolledCourseDetails.queryOptions({
-        //         courseSlug: slug,
-        //     }),
-        // ),
+        prefetch(
+            trpc.getEnrolledCourseDetails.queryOptions({
+                courseSlug: slug,
+            }),
+        ),
     ];
 
-    // if (currentRole === 'student') {
-    //     promises.push(
-    //         prefetchMock(
-    //             trpcMock.getStudentProgress.queryOptions({
-    //                 courseSlug: slug,
-    //             }),
-    //         ),
-    //         prefetchMock(
-    //             trpcMock.listIncludedCoachingSessions.queryOptions({
-    //                 courseSlug: slug,
-    //             }),
-    //         ),
-    //     );
-    // }
+    if (currentRole === 'student') {
+        promises.push(
+            prefetchMock(
+                trpcMock.getStudentProgress.queryOptions({
+                    courseSlug: slug,
+                }),
+            ),
+            prefetchMock(
+                trpcMock.listIncludedCoachingSessions.queryOptions({
+                    courseSlug: slug,
+                }),
+            ),
+        );
+    }
 
-    await Promise.all([]);
+    await Promise.all(promises);
 }
 
 function renderEnrolledCourse({

--- a/apps/cms/src/lib/infrastructure/server/pages/list-platforms-rsc.tsx
+++ b/apps/cms/src/lib/infrastructure/server/pages/list-platforms-rsc.tsx
@@ -4,11 +4,11 @@ import DefaultLoadingWrapper from '../../client/wrappers/default-loading';
 import { HydrateClient, prefetch, getServerTRPC } from '../config/trpc/cms-server';
 
 export default async function ListPlatformsServerComponent() {
-    // const trpc = getServerTRPC();
-    // await Promise.all([
-    //     prefetch(trpc.getHomePage.queryOptions({})),
-    //     prefetch(trpc.listTopics.queryOptions({})),
-    // ]);
+    const trpc = getServerTRPC();
+    await Promise.all([
+        prefetch(trpc.getHomePage.queryOptions({})),
+        prefetch(trpc.listTopics.queryOptions({})),
+    ]);
 
     return (
         <>

--- a/apps/cms/src/lib/infrastructure/server/pages/workspace/coach-students-rsc.tsx
+++ b/apps/cms/src/lib/infrastructure/server/pages/workspace/coach-students-rsc.tsx
@@ -3,7 +3,7 @@ import DefaultLoadingWrapper from '../../../client/wrappers/default-loading';
 import { redirect } from 'next/navigation';
 import getSession from '../../config/auth/get-session';
 import CoachStudents from '../../../client/pages/workspace/coach-students';
-import { HydrateClient, prefetch, getServerTRPC } from '../../config/trpc/cms-server';
+import { HydrateClient, prefetch, trpc } from '../../config/trpc/server';
 
 export default async function CoachStudentsServerComponent() {
     const session = await getSession();
@@ -20,8 +20,16 @@ export default async function CoachStudentsServerComponent() {
         throw new Error('Access denied. Only coaches and course creators can access this page.');
     }
 
-    // Prefetch removed: trpc.listCoachStudents does not exist on the server proxy.
-    // Data will be fetched on the client-side component instead.
+    await Promise.all([
+        prefetch(
+            trpc.listCoachStudents.queryOptions({
+                pagination: {
+                    page: 1,
+                    pageSize: 20,
+                },
+            }),
+        ),
+    ]);
 
     return (
         <>

--- a/apps/cms/src/lib/infrastructure/server/pages/workspace/user-courses-rsc.tsx
+++ b/apps/cms/src/lib/infrastructure/server/pages/workspace/user-courses-rsc.tsx
@@ -20,8 +20,8 @@ export default async function UserCoursesServerComponent() {
         throw new Error();
     }
 
-    // const trpc = getServerTRPC();
-    // await Promise.all([prefetch(trpc.listUserCourses.queryOptions({}))]);
+    const trpc = getServerTRPC();
+    await Promise.all([prefetch(trpc.listUserCourses.queryOptions({}))]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/about-page-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/about-page-rsc.tsx
@@ -2,17 +2,15 @@
 // TSK: TSK-2
 // Features: getPlatformLanguage
 
-import { HydrateClient } from '../config/trpc/cms-server';
+import { HydrateClient, prefetch, trpc } from '../config/trpc/cms-server';
 import { Suspense } from 'react';
 import AboutPage from '../../../../lib/infrastructure/client/pages/about-page';
 import DefaultLoadingWrapper from '../../client/wrappers/default-loading';
 
 export default async function AboutPageServerComponent() {
-    // TODO: Add TRPC prefetching for your page data
-    // Based on discovered patterns in this project:
-    // await Promise.all([
-    //     prefetch(trpc.getPlatformLanguage.queryOptions({})),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.getPlatformLanguage.queryOptions({})),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/coaching-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/coaching-rsc.tsx
@@ -8,11 +8,11 @@ interface CoachingProps {
 }
 
 export default async function CoachingServerComponent(props: CoachingProps) {
-    // await Promise.all([
-    //     prefetch(trpc.getCoachingPage.queryOptions({})),
-    //     prefetch(trpc.listTopicsByCategory.queryOptions({})),
-    //     prefetch(trpc.listCoachingOfferings.queryOptions({})),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.getCoachingPage.queryOptions({})),
+        prefetch(trpc.listTopicsByCategory.queryOptions({})),
+        prefetch(trpc.listCoachingOfferings.queryOptions({})),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/course-completion-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/course-completion-rsc.tsx
@@ -2,7 +2,7 @@
 // TSK: TSK-3
 // Features: createCourseReview, getCourseCertificateData, downloadCertificate, getCourseStatus
 
-import { HydrateClient } from '../config/trpc/cms-server';
+import { HydrateClient, prefetch, trpc } from '../config/trpc/cms-server';
 import { Suspense } from 'react';
 import CourseCompletion from '../../client/pages/course-completion';
 import DefaultLoadingWrapper from '../../client/wrappers/default-loading';
@@ -14,12 +14,10 @@ interface CourseCompletionServerComponentProps {
 export default async function CourseCompletionServerComponent(
     props: CourseCompletionServerComponentProps,
 ) {
-    // TODO: Add TRPC prefetching for course completion data
-    // Based on discovered patterns in this project:
-    // await Promise.all([
-    //     prefetch(trpc.getCourseStatus.queryOptions({ courseSlug: props.slug })),
-    //     prefetch(trpc.getCourseCertificateData.queryOptions({ courseSlug: props.slug })),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.getCourseStatus.queryOptions({ courseSlug: props.slug })),
+        prefetch(trpc.getCourseCertificateData.queryOptions({ courseSlug: props.slug })),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
@@ -144,29 +144,29 @@ async function prefetchIntroductionData(
     currentRole: string,
 ): Promise<void> {
     const promises = [
-        // prefetch(
-        //     trpc.getEnrolledCourseDetails.queryOptions({
-        //         courseSlug: slug,
-        //     }),
-        // ),
+        prefetch(
+            trpc.getEnrolledCourseDetails.queryOptions({
+                courseSlug: slug,
+            }),
+        ),
     ];
 
-    // if (currentRole === 'student') {
-    //     promises.push(
-    //         prefetchMock(
-    //             trpcMock.getStudentProgress.queryOptions({
-    //                 courseSlug: slug,
-    //             }),
-    //         ),
-    //         prefetchMock(
-    //             trpcMock.listIncludedCoachingSessions.queryOptions({
-    //                 courseSlug: slug,
-    //             }),
-    //         ),
-    //     );
-    // }
+    if (currentRole === 'student') {
+        promises.push(
+            prefetchMock(
+                trpcMock.getStudentProgress.queryOptions({
+                    courseSlug: slug,
+                }),
+            ),
+            prefetchMock(
+                trpcMock.listIncludedCoachingSessions.queryOptions({
+                    courseSlug: slug,
+                }),
+            ),
+        );
+    }
 
-    await Promise.all([]);
+    await Promise.all(promises);
 }
 
 function renderEnrolledCourse({

--- a/apps/platform/src/lib/infrastructure/server/pages/home-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/home-rsc.tsx
@@ -4,10 +4,10 @@ import DefaultLoadingWrapper from '../../client/wrappers/default-loading';
 import { HydrateClient, prefetch, trpc } from '../config/trpc/cms-server';
 
 export default async function HomeServerComponent() {
-    // await Promise.all([
-    //     prefetch(trpc.getHomePage.queryOptions({})),
-    //     prefetch(trpc.listTopics.queryOptions({})),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.getHomePage.queryOptions({})),
+        prefetch(trpc.listTopics.queryOptions({})),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/offers-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/offers-rsc.tsx
@@ -8,10 +8,10 @@ interface OffersProps {
 }
 
 export default async function OffersServerComponent(props: OffersProps) {
-    // await Promise.all([
-    //     prefetch(trpc.getOffersPageOutline.queryOptions({})),
-    //     prefetch(trpc.listTopicsByCategory.queryOptions({})),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.getOffersPageOutline.queryOptions({})),
+        prefetch(trpc.listTopicsByCategory.queryOptions({})),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/profile-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/profile-rsc.tsx
@@ -3,7 +3,7 @@
 // Features: listTopics, getProfessionalProfile, saveProfessionalProfile
 // Route: /workspace/profile
 
-import { HydrateClient, trpc } from '../config/trpc/cms-server';
+import { HydrateClient, trpc, prefetch } from '../config/trpc/cms-server';
 import { Suspense } from 'react';
 import { DefaultLoading } from '@maany_shr/e-class-ui-kit';
 import Profile from '../../client/pages/profile';
@@ -13,11 +13,10 @@ interface ProfileProps {
 }
 
 export default async function ProfileServerComponent(props: ProfileProps) {
-	// TODO: Prefetch data for the profile page
-	// await Promise.all([
-	//	trpc.getProfessionalProfile.prefetch(),
-	// 	trpc.listTopics.prefetch(),
-	// ]);
+	await Promise.all([
+		prefetch(trpc.getProfessionalProfile.queryOptions({})),
+		prefetch(trpc.listTopics.queryOptions({})),
+	]);
 
 	return (
 		<>

--- a/apps/platform/src/lib/infrastructure/server/pages/single-student-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/single-student-rsc.tsx
@@ -6,7 +6,7 @@ import DefaultLoadingWrapper from '../../client/wrappers/default-loading';
 import { redirect } from 'next/navigation';
 import getSession from '../config/auth/get-session';
 import SingleStudent from '../../client/pages/student/single-student';
-import { HydrateClient } from '../config/trpc/cms-server';
+import { HydrateClient, prefetch, trpc } from '../config/trpc/cms-server';
 import { TLocale } from '@maany_shr/e-class-translations';
 
 interface SingleStudentServerComponentProps {
@@ -38,11 +38,9 @@ export default async function SingleStudentServerComponent({
         throw new Error('Access denied. Only coaches and admins can access student details.');
     }
 
-    // TODO: Add TRPC prefetching for student data
-    // Based on discovered patterns in this project:
-    // await Promise.all([
-    //     prefetch(trpc.listStudentInteractions.queryOptions({ studentSlug: slug })),
-    // ]);
+    await Promise.all([
+        prefetch(trpc.listStudentInteractions.queryOptions({ studentId, courseSlug })),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/workspace/coach-students-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/workspace/coach-students-rsc.tsx
@@ -3,7 +3,7 @@ import DefaultLoadingWrapper from '../../../client/wrappers/default-loading';
 import { redirect } from 'next/navigation';
 import getSession from '../../config/auth/get-session';
 import CoachStudents from '../../../client/pages/workspace/coach-students';
-import { HydrateClient, prefetch, trpc } from '../../config/trpc/cms-server';
+import { HydrateClient, prefetch, trpc } from '../../config/trpc/server';
 
 export default async function CoachStudentsServerComponent() {
     const session = await getSession();
@@ -20,8 +20,16 @@ export default async function CoachStudentsServerComponent() {
         throw new Error('Access denied. Only coaches and course creators can access this page.');
     }
 
-    // Prefetch removed: trpc.listCoachStudents does not exist on the server proxy.
-    // Data will be fetched on the client-side component instead.
+    await Promise.all([
+        prefetch(
+            trpc.listCoachStudents.queryOptions({
+                pagination: {
+                    page: 1,
+                    pageSize: 20,
+                },
+            }),
+        ),
+    ]);
 
     return (
         <>

--- a/apps/platform/src/lib/infrastructure/server/pages/workspace/user-courses-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/workspace/user-courses-rsc.tsx
@@ -20,7 +20,7 @@ export default async function UserCoursesServerComponent() {
         throw new Error();
     }
 
-    // await Promise.all([prefetch(trpc.listUserCourses.queryOptions({}))]);
+    await Promise.all([prefetch(trpc.listUserCourses.queryOptions({}))]);
 
     return (
         <>


### PR DESCRIPTION
## Summary
- Enable TRPC prefetching in 13 server components across CMS and Platform apps
- Uncomment and activate previously disabled prefetch calls
- Fix import issues for MockRouter in coach-students components
- Correct query parameters for single-student and profile components

## Changes
### CMS App
- `course-rsc.tsx`: Enable prefetching for enrolled course details and student progress
- `list-platforms-rsc.tsx`: Enable home page and topics prefetching
- `workspace/user-courses-rsc.tsx`: Enable user courses prefetching
- `workspace/coach-students-rsc.tsx`: Enable coach students list prefetching (using MockRouter)
- `platform/[platform_slug]/[platform_locale]/page.tsx`: Enable topics and categories prefetching

### Platform App
- `home-rsc.tsx`: Enable home page and topics prefetching
- `course-rsc.tsx`: Enable enrolled course details and student progress prefetching
- `course-completion-rsc.tsx`: Enable course status and certificate data prefetching
- `coaching-rsc.tsx`: Enable coaching page, topics, and offerings prefetching
- `about-page-rsc.tsx`: Enable platform language prefetching
- `single-student-rsc.tsx`: Enable student interactions prefetching (fixed query params)
- `profile-rsc.tsx`: Enable professional profile and topics prefetching (fixed query options)
- `offers-rsc.tsx`: Enable offers page and topics prefetching
- `workspace/user-courses-rsc.tsx`: Enable user courses prefetching
- `workspace/coach-students-rsc.tsx`: Enable coach students list prefetching (using MockRouter)

## Impact
- Improved initial page load performance through server-side data prefetching
- Data hydration happens on the server before client components mount
- Reduced client-side loading states and flicker

## Test Plan
- [x] Build succeeds for both CMS and Platform apps
- [ ] Verify prefetched data is correctly hydrated on initial page load
- [ ] Test all affected pages render without errors
- [ ] Confirm no regression in existing functionality