### PR TITLE
Add entrypoint script for cms-rest service cleanup

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -70,6 +70,7 @@ services:
     ports:
       - "5173:5173"
     restart: always
+    entrypoint: ["/bin/bash", "-c", "rm -rf /opt/dadai/app/.nx || true && apps/cms-rest/config/docker-entrypoint.sh"]
     environment:
       - NODE_ENV=production
       - HOST=0.0.0.0


### PR DESCRIPTION
Introduce an entrypoint script in the cms-rest Docker Compose service to remove previous build artifacts before starting the container.