### PR TITLE
Add presenter scaffold generator and related scripts

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,39 @@
+# Python virtual environment
+.venv/
+venv/
+env/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/tools/README.presenter-scaffold.md
+++ b/tools/README.presenter-scaffold.md
@@ -1,0 +1,418 @@
+# DAD E-Class Tools
+
+Python tools for generating presenter scaffolds in the DAD E-Class project.
+
+---
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Presenter Scaffold Generator](#presenter-scaffold-generator)
+- [Setup](#setup)
+- [Usage Examples](#usage-examples)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick Start
+
+### First Time Setup
+
+```bash
+cd tools
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+### Generate Presenter Files
+
+```bash
+# Use any casing format:
+./tools/scaffold-presenter cms SaveHomePage
+./tools/scaffold-presenter cms save-home-page
+./tools/scaffold-presenter platform GetCourseDetails
+```
+
+---
+
+## Presenter Scaffold Generator
+
+A deterministic script that generates complete presenter layer files (view-model, presenter, and React hook).
+
+### Features
+
+✅ **Smart Case Conversion** - Accepts PascalCase, camelCase, kebab-case, snake_case
+✅ **Automatic Imports** - Correctly imports from `@dream-aim-deliver/e-class-cms-rest`
+✅ **Complete Layer** - Generates view-model, presenter, and React hook
+✅ **Index Updates** - Automatically updates `index.ts` exports
+✅ **Type-Safe** - Fully typed TypeScript files
+
+### Usage
+
+```bash
+./tools/scaffold-presenter <project> <feature-name>
+```
+
+**Arguments:**
+- `project`: Either `'cms'` or `'platform'`
+- `feature-name`: Any casing format (auto-converted to kebab-case)
+
+### Generated Files
+
+For feature `save-home-page` in project `cms`:
+
+1. **View Model**: `packages/models/src/view-models/save-home-page-view-model.ts`
+   - Imports from `@dream-aim-deliver/e-class-cms-rest`
+   - Three view modes: `default`, `kaboom`, `not-found`
+
+2. **Presenter**: `apps/cms/src/lib/infrastructure/common/presenters/save-home-page-presenter.ts`
+   - Imports usecase models from cms-rest
+   - Implements `presentSuccess()` and `presentError()`
+
+3. **React Hook**: `apps/cms/src/lib/infrastructure/client/hooks/use-save-home-page-presenter.ts`
+   - Memoized presenter instance
+   - Ready to use in components
+
+4. **Index**: Updates `packages/models/src/view-models/index.ts` with new export
+
+### Case Conversion Examples
+
+The script uses **pyhumps** for smart case conversion:
+
+```bash
+# All produce the same output:
+./tools/scaffold-presenter cms SaveHomePage     # PascalCase
+./tools/scaffold-presenter cms save-home-page   # kebab-case
+./tools/scaffold-presenter cms save_home_page   # snake_case
+./tools/scaffold-presenter cms saveHomePage     # camelCase
+
+# Result: save-home-page (kebab-case files, PascalCase types)
+```
+
+### Integration Example
+
+```typescript
+import { useState } from 'react';
+import { viewModels } from '@maany_shr/e-class-models';
+import { useSaveHomePagePresenter } from '@/hooks/use-save-home-page-presenter';
+
+function SaveHomePageComponent() {
+  const [viewModel, setViewModel] = useState<viewModels.TSaveHomePageViewModel>();
+  const { presenter } = useSaveHomePagePresenter(setViewModel);
+
+  // Execute usecase and present
+  const handleSave = async (data: any) => {
+    const response = await controller.execute({ data }, {});
+    presenter.present(response);
+  };
+
+  // Render based on view mode
+  if (viewModel?.mode === 'default') return <SuccessView data={viewModel.data} />;
+  if (viewModel?.mode === 'not-found') return <NotFoundView />;
+  if (viewModel?.mode === 'kaboom') return <ErrorView error={viewModel.data} />;
+
+  return null;
+}
+```
+
+---
+
+## Setup
+
+### Virtual Environment
+
+The scripts use a Python virtual environment with isolated dependencies.
+
+**Create (first time only):**
+```bash
+cd tools
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+**Verify:**
+```bash
+tools/.venv/bin/python3 -c "import humps; print('✓ Ready!')"
+```
+
+### Dependencies
+
+Current dependencies (from `requirements.txt`):
+- **pyhumps** (3.8.0): Smart case conversion
+
+**Add dependency:**
+```bash
+cd tools
+echo "package-name==version" >> requirements.txt
+.venv/bin/pip install -r requirements.txt
+```
+
+### Files
+
+```
+tools/
+├── .venv/                           # Virtual environment (gitignored)
+├── .gitignore                       # Excludes .venv and cache
+├── requirements.txt                 # Python dependencies
+├── scaffold-presenter               # Bash wrapper (uses .venv)
+├── generate-presenter-scaffold.py   # Main generator script
+└── README.md                        # This file
+```
+
+---
+
+## Usage Examples
+
+### Basic Examples
+
+```bash
+# CMS project
+./tools/scaffold-presenter cms save-home-page
+./tools/scaffold-presenter cms create-topic
+./tools/scaffold-presenter cms delete-category
+
+# Platform project
+./tools/scaffold-presenter platform get-course-details
+./tools/scaffold-presenter platform save-personal-profile
+./tools/scaffold-presenter platform schedule-coaching-session
+```
+
+### Different Casing Formats
+
+```bash
+# PascalCase input
+./tools/scaffold-presenter cms CreateTopic
+# Output: create-topic (files), CreateTopic (types)
+
+# camelCase input
+./tools/scaffold-presenter cms createTopic
+# Output: create-topic (files), CreateTopic (types)
+
+# snake_case input
+./tools/scaffold-presenter cms create_topic
+# Output: create-topic (files), CreateTopic (types)
+
+# kebab-case input
+./tools/scaffold-presenter cms create-topic
+# Output: create-topic (files), CreateTopic (types)
+```
+
+### CRUD Operations
+
+```bash
+# Create
+./tools/scaffold-presenter cms create-topic
+./tools/scaffold-presenter cms create-category
+
+# Read/Get
+./tools/scaffold-presenter cms get-topic-details
+./tools/scaffold-presenter cms list-topics
+
+# Update/Save
+./tools/scaffold-presenter cms update-topic
+./tools/scaffold-presenter cms save-topic
+
+# Delete
+./tools/scaffold-presenter cms delete-topic
+```
+
+### Complex Names
+
+```bash
+# Multi-word features
+./tools/scaffold-presenter cms list-student-coaching-sessions
+./tools/scaffold-presenter platform get-course-certificate-data
+./tools/scaffold-presenter cms list-coach-student-courses
+```
+
+### Sample Output
+
+```
+============================================================
+Presenter Scaffold Generator
+============================================================
+Project:      cms
+Feature:      save-home-page
+PascalCase:   SaveHomePage
+camelCase:    saveHomePage
+Converter:    humps (smart case conversion)
+============================================================
+
+Generating files...
+
+✓ Generated: packages/models/src/view-models/save-home-page-view-model.ts
+✓ Generated: apps/cms/src/lib/infrastructure/common/presenters/save-home-page-presenter.ts
+✓ Generated: apps/cms/src/lib/infrastructure/client/hooks/use-save-home-page-presenter.ts
+✓ Updated: packages/models/src/view-models/index.ts
+
+============================================================
+✓ Generation complete!
+============================================================
+```
+
+---
+
+## Troubleshooting
+
+### Virtual Environment Not Found
+
+```bash
+Error: Virtual environment not found at tools/.venv
+```
+
+**Fix:**
+```bash
+cd tools
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+### Permission Denied
+
+```bash
+./tools/scaffold-presenter: Permission denied
+```
+
+**Fix:**
+```bash
+chmod +x tools/scaffold-presenter
+```
+
+### Import Errors in Generated Files
+
+If TypeScript complains about imports:
+
+1. Verify usecase models exist in `@dream-aim-deliver/e-class-cms-rest`
+2. Check feature name matches usecase name exactly
+3. Run lint to verify:
+   ```bash
+   pnpm nx run models:lint
+   pnpm nx run cms:lint
+   ```
+
+### View Model Types Not Found
+
+Check that export was added to `packages/models/src/view-models/index.ts`:
+
+```typescript
+export * from './your-feature-view-model';
+```
+
+### Python Version Issues
+
+**Check version:**
+```bash
+python3 --version  # Requires 3.6+
+```
+
+**Use specific version:**
+```bash
+cd tools
+python3.11 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+### Testing the Generator
+
+```bash
+# Test with sample feature
+./tools/scaffold-presenter cms test-feature
+
+# Verify files created
+ls packages/models/src/view-models/test-feature-view-model.ts
+ls apps/cms/src/lib/infrastructure/common/presenters/test-feature-presenter.ts
+
+# Clean up test files
+rm packages/models/src/view-models/test-feature-view-model.ts
+rm apps/cms/src/lib/infrastructure/common/presenters/test-feature-presenter.ts
+rm apps/cms/src/lib/infrastructure/client/hooks/use-test-feature-presenter.ts
+# Remove from index.ts manually
+```
+
+---
+
+## Generated Code Structure
+
+### View Model Template
+
+```typescript
+import { z } from 'zod';
+import {
+    BaseDiscriminatedViewModeSchemaFactory,
+    BaseViewModelDiscriminatedUnionSchemaFactory
+} from '@dream-aim-deliver/dad-cats';
+import { FeatureSuccessResponseSchema } from '@dream-aim-deliver/e-class-cms-rest';
+
+export const FeatureViewModelSchemaMap = {
+    default: FeatureDefaultViewModelSchema,
+    kaboom: FeatureKaboomViewModelSchema,
+    notFound: FeatureNotFoundViewModelSchema,
+};
+
+export const FeatureViewModelSchema = BaseViewModelDiscriminatedUnionSchemaFactory(FeatureViewModelSchemaMap);
+export type TFeatureViewModel = z.infer<typeof FeatureViewModelSchema>;
+```
+
+### Presenter Template
+
+```typescript
+import { viewModels } from '@maany_shr/e-class-models';
+import {
+    FeatureUseCaseResponseSchema,
+    TFeatureUseCaseResponse,
+    TFeatureErrorResponse,
+} from '@dream-aim-deliver/e-class-cms-rest';
+
+export default class FeaturePresenter extends BasePresenter<...> {
+    presentSuccess(response: ...) {
+        return { mode: 'default', data: { ...response.data } };
+    }
+
+    presentError(response: ...) {
+        return { mode: 'kaboom', data: { ...response.data } };
+    }
+}
+```
+
+### Hook Template
+
+```typescript
+import { viewModels } from '@maany_shr/e-class-models';
+import { useMemo } from 'react';
+import FeaturePresenter from '../../common/presenters/feature-presenter';
+
+export function useFeaturePresenter(
+    setViewModel: (viewModel: viewModels.TFeatureViewModel) => void,
+) {
+    const presenter = useMemo(
+        () => new FeaturePresenter(setViewModel, {}),
+        [setViewModel],
+    );
+    return { presenter };
+}
+```
+
+---
+
+## Tips
+
+1. **Match usecase names**: Feature name should match your usecase name in cms-rest
+2. **Customize presenters**: Edit `presentSuccess()` and `presentError()` methods as needed
+3. **Add view modes**: Edit view model to add `loading`, `empty`, or `invalid` modes
+4. **Verify imports**: Run lint after generation to catch import issues early
+
+---
+
+## Related
+
+- Based on `/dad:v1:feature:presenter-scaffold` command
+- For interactive version with discovery: Use the slash command instead
+- Project structure: Standard DAD E-Class monorepo layout
+
+---
+
+## Requirements
+
+- Python 3.6+
+- Dependencies: `@dream-aim-deliver/e-class-cms-rest`, `@maany_shr/e-class-models`, `@dream-aim-deliver/dad-cats`
+- Standard DAD E-Class directory structure

--- a/tools/generate-presenter-scaffold.py
+++ b/tools/generate-presenter-scaffold.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+Deterministic Presenter Scaffold Generator
+
+Generates complete presenter layer (view-model, presenter, hook) for DAD E-Class projects.
+Accepts any case format for feature names and handles imports from cms-rest properly.
+
+Setup:
+    cd tools
+    python3 -m venv .venv
+    .venv/bin/pip install -r requirements.txt
+
+Usage:
+    tools/.venv/bin/python3 tools/generate-presenter-scaffold.py <project> <feature-name>
+
+    Or use the wrapper:
+    ./tools/scaffold-presenter <project> <feature-name>
+
+Arguments:
+    project: 'platform' or 'cms'
+    feature-name: Any casing (e.g., 'SaveHomePage', 'save-home-page', 'save_home_page')
+
+Example:
+    ./tools/scaffold-presenter cms save-home-page
+    ./tools/scaffold-presenter platform GetCourseDetails
+"""
+
+import os
+import sys
+import re
+from pathlib import Path
+from typing import Tuple
+
+# Try to use humps library for better case conversion, fallback to built-in
+try:
+    import humps
+    HAS_HUMPS = True
+except ImportError:
+    HAS_HUMPS = False
+
+
+def to_kebab_case(s: str) -> str:
+    """Convert any case format to kebab-case using humps if available."""
+    if HAS_HUMPS:
+        return humps.kebabize(s)
+
+    # Fallback: built-in conversion
+    # Handle acronyms and special patterns
+    s = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', s)
+    s = re.sub('([a-z0-9])([A-Z])', r'\1-\2', s)
+    s = s.replace('_', '-')
+    return s.lower()
+
+
+def to_pascal_case(s: str) -> str:
+    """Convert kebab-case to PascalCase using humps if available."""
+    if HAS_HUMPS:
+        return humps.pascalize(s)
+
+    # Fallback: built-in conversion
+    return ''.join(word.capitalize() for word in s.split('-'))
+
+
+def to_camel_case(s: str) -> str:
+    """Convert kebab-case to camelCase using humps if available."""
+    if HAS_HUMPS:
+        return humps.camelize(s)
+
+    # Fallback: built-in conversion
+    words = s.split('-')
+    return words[0].lower() + ''.join(word.capitalize() for word in words[1:])
+
+
+def generate_view_model(feature_kebab: str, feature_pascal: str, output_dir: Path) -> None:
+    """Generate view model file with cms-rest import."""
+    content = f'''import {{ z }} from 'zod';
+import {{
+    BaseDiscriminatedViewModeSchemaFactory,
+    BaseErrorContextSchema,
+    BaseErrorDataSchema,
+    BaseErrorDataSchemaFactory,
+    BaseViewModelDiscriminatedUnionSchemaFactory
+}} from '@dream-aim-deliver/dad-cats';
+import {{ {feature_pascal}SuccessResponseSchema }} from '@dream-aim-deliver/e-class-cms-rest';
+
+// Extract success data from usecase response
+export const {feature_pascal}SuccessSchema = {feature_pascal}SuccessResponseSchema.shape.data;
+export type T{feature_pascal}Success = z.infer<typeof {feature_pascal}SuccessSchema>;
+
+// Define view mode schemas
+const {feature_pascal}DefaultViewModelSchema = BaseDiscriminatedViewModeSchemaFactory(
+    "default",
+    {feature_pascal}SuccessSchema
+);
+
+const {feature_pascal}KaboomViewModelSchema = BaseDiscriminatedViewModeSchemaFactory(
+    "kaboom",
+    BaseErrorDataSchemaFactory(BaseErrorDataSchema, BaseErrorContextSchema)
+);
+
+const {feature_pascal}NotFoundViewModelSchema = BaseDiscriminatedViewModeSchemaFactory(
+    "not-found",
+    BaseErrorDataSchemaFactory(BaseErrorDataSchema, BaseErrorContextSchema)
+);
+
+// Create schema map with all view modes
+export const {feature_pascal}ViewModelSchemaMap = {{
+    default: {feature_pascal}DefaultViewModelSchema,
+    kaboom: {feature_pascal}KaboomViewModelSchema,
+    notFound: {feature_pascal}NotFoundViewModelSchema,
+}};
+export type T{feature_pascal}ViewModelSchemaMap = typeof {feature_pascal}ViewModelSchemaMap;
+
+// Create discriminated union of all view modes
+export const {feature_pascal}ViewModelSchema = BaseViewModelDiscriminatedUnionSchemaFactory({feature_pascal}ViewModelSchemaMap);
+export type T{feature_pascal}ViewModel = z.infer<typeof {feature_pascal}ViewModelSchema>;
+'''
+
+    file_path = output_dir / f"{feature_kebab}-view-model.ts"
+    file_path.write_text(content)
+    print(f"✓ Generated: {file_path}")
+
+
+def generate_presenter(feature_kebab: str, feature_pascal: str, output_dir: Path) -> None:
+    """Generate presenter file with cms-rest imports."""
+    content = f'''import {{ viewModels }} from '@maany_shr/e-class-models';
+import {{
+    {feature_pascal}UseCaseResponseSchema,
+    T{feature_pascal}UseCaseResponse,
+    T{feature_pascal}ErrorResponse,
+}} from '@dream-aim-deliver/e-class-cms-rest';
+import {{
+    BasePresenter,
+    TBaseResponseResponseMiddleware,
+    UnhandledErrorResponse
+}} from '@dream-aim-deliver/dad-cats';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type T{feature_pascal}PresenterUtilities = {{}};
+
+export const {feature_pascal}ResponseMiddleware =
+    {{}} satisfies TBaseResponseResponseMiddleware<
+        T{feature_pascal}UseCaseResponse,
+        viewModels.T{feature_pascal}ViewModel,
+        T{feature_pascal}PresenterUtilities
+    >;
+
+type T{feature_pascal}ResponseMiddleware = typeof {feature_pascal}ResponseMiddleware;
+
+export default class {feature_pascal}Presenter extends BasePresenter<
+    T{feature_pascal}UseCaseResponse,
+    viewModels.T{feature_pascal}ViewModel,
+    T{feature_pascal}PresenterUtilities,
+    T{feature_pascal}ResponseMiddleware
+> {{
+    constructor(
+        setViewModel: (viewModel: viewModels.T{feature_pascal}ViewModel) => void,
+        viewUtilities: T{feature_pascal}PresenterUtilities,
+    ) {{
+        super({{
+            schemas: {{
+                responseModel: {feature_pascal}UseCaseResponseSchema,
+                viewModel: viewModels.{feature_pascal}ViewModelSchema
+            }},
+            middleware: {feature_pascal}ResponseMiddleware,
+            viewUtilities: viewUtilities,
+            setViewModel: setViewModel
+        }});
+    }}
+
+    presentSuccess(
+        response: Extract<
+            T{feature_pascal}UseCaseResponse,
+            {{ success: true }}
+        >,
+    ): viewModels.T{feature_pascal}ViewModel {{
+        return {{
+            mode: 'default',
+            data: {{
+                ...response.data
+            }}
+        }};
+    }}
+
+    presentError(
+        response: UnhandledErrorResponse<
+            T{feature_pascal}ErrorResponse,
+            T{feature_pascal}ResponseMiddleware
+        >,
+    ): viewModels.T{feature_pascal}ViewModel {{
+        return {{
+            mode: 'kaboom',
+            data: {{
+                message: response.data.message,
+                operation: response.data.operation,
+                context: response.data.context
+            }}
+        }};
+    }}
+}}
+'''
+
+    file_path = output_dir / f"{feature_kebab}-presenter.ts"
+    file_path.write_text(content)
+    print(f"✓ Generated: {file_path}")
+
+
+def generate_hook(feature_kebab: str, feature_pascal: str, feature_camel: str, output_dir: Path) -> None:
+    """Generate React hook file."""
+    content = f'''import {{ viewModels }} from '@maany_shr/e-class-models';
+import {{ useMemo }} from 'react';
+import {feature_pascal}Presenter, {{
+    T{feature_pascal}PresenterUtilities,
+}} from '../../common/presenters/{feature_kebab}-presenter';
+
+export function use{feature_pascal}Presenter(
+    setViewModel: (viewModel: viewModels.T{feature_pascal}ViewModel) => void,
+) {{
+    const presenterUtilities: T{feature_pascal}PresenterUtilities = {{}};
+    const presenter = useMemo(
+        () => new {feature_pascal}Presenter(setViewModel, presenterUtilities),
+        [setViewModel],
+    );
+    return {{ presenter }};
+}}
+'''
+
+    file_path = output_dir / f"use-{feature_kebab}-presenter.ts"
+    file_path.write_text(content)
+    print(f"✓ Generated: {file_path}")
+
+
+def update_view_models_index(feature_kebab: str, index_path: Path) -> None:
+    """Update view models index.ts with new export."""
+    if not index_path.exists():
+        print(f"✗ Warning: Index file not found: {index_path}")
+        return
+
+    content = index_path.read_text()
+    export_line = f"export * from './{feature_kebab}-view-model';"
+
+    # Check if already exists
+    if export_line in content:
+        print(f"✓ Export already exists in {index_path}")
+        return
+
+    # Append at the end
+    if not content.endswith('\n'):
+        content += '\n'
+    content += export_line + '\n'
+
+    index_path.write_text(content)
+    print(f"✓ Updated: {index_path}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Error: Missing required arguments")
+        print("\nUsage:")
+        print("  python3 tools/generate-presenter-scaffold.py <project> <feature-name>")
+        print("\nArguments:")
+        print("  project:      'platform' or 'cms'")
+        print("  feature-name: Any casing (e.g., 'SaveHomePage', 'save-home-page')")
+        print("\nExample:")
+        print("  python3 tools/generate-presenter-scaffold.py cms save-home-page")
+        sys.exit(1)
+
+    project = sys.argv[1].lower()
+    feature_input = sys.argv[2]
+
+    # Validate project
+    if project not in ['platform', 'cms']:
+        print(f"Error: Invalid project '{project}'. Must be 'platform' or 'cms'")
+        sys.exit(1)
+
+    # Convert to different cases
+    feature_kebab = to_kebab_case(feature_input)
+    feature_pascal = to_pascal_case(feature_kebab)
+    feature_camel = to_camel_case(feature_kebab)
+
+    print(f"\n{'='*60}")
+    print(f"Presenter Scaffold Generator")
+    print(f"{'='*60}")
+    print(f"Project:      {project}")
+    print(f"Feature:      {feature_kebab}")
+    print(f"PascalCase:   {feature_pascal}")
+    print(f"camelCase:    {feature_camel}")
+    if HAS_HUMPS:
+        print(f"Converter:    humps (smart case conversion)")
+    else:
+        print(f"Converter:    built-in (install 'humps' for better conversion)")
+    print(f"{'='*60}\n")
+
+    # Define paths
+    repo_root = Path(__file__).parent.parent
+    view_models_dir = repo_root / "packages/models/src/view-models"
+    presenters_dir = repo_root / f"apps/{project}/src/lib/infrastructure/common/presenters"
+    hooks_dir = repo_root / f"apps/{project}/src/lib/infrastructure/client/hooks"
+    view_models_index = view_models_dir / "index.ts"
+
+    # Validate directories exist
+    for dir_path, name in [(view_models_dir, "View models"),
+                            (presenters_dir, "Presenters"),
+                            (hooks_dir, "Hooks")]:
+        if not dir_path.exists():
+            print(f"✗ Error: {name} directory not found: {dir_path}")
+            sys.exit(1)
+
+    print("Generating files...\n")
+
+    # Generate files
+    try:
+        generate_view_model(feature_kebab, feature_pascal, view_models_dir)
+        generate_presenter(feature_kebab, feature_pascal, presenters_dir)
+        generate_hook(feature_kebab, feature_pascal, feature_camel, hooks_dir)
+        update_view_models_index(feature_kebab, view_models_index)
+
+        print(f"\n{'='*60}")
+        print("✓ Generation complete!")
+        print(f"{'='*60}")
+        print("\nGenerated files:")
+        print(f"  1. View Model:  {view_models_dir}/{feature_kebab}-view-model.ts")
+        print(f"  2. Presenter:   {presenters_dir}/{feature_kebab}-presenter.ts")
+        print(f"  3. Hook:        {hooks_dir}/use-{feature_kebab}-presenter.ts")
+        print(f"  4. Index:       {view_models_index} (updated)")
+
+        print("\nImports:")
+        print(f"  - View models from: @dream-aim-deliver/e-class-cms-rest")
+        print(f"  - Usecase models from: @dream-aim-deliver/e-class-cms-rest")
+        print(f"  - Presenter utilities from: @dream-aim-deliver/dad-cats")
+
+        print("\nView modes:")
+        print("  - default:   Success state with full data")
+        print("  - kaboom:    General unhandled error")
+        print("  - not-found: Resource not found (404)")
+
+        print(f"\n{'='*60}\n")
+
+    except Exception as e:
+        print(f"\n✗ Error during generation: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,5 @@
+# Python dependencies for DAD E-Class tools
+
+# Smart case conversion library
+# Handles PascalCase, camelCase, snake_case, kebab-case conversions
+pyhumps==3.8.0

--- a/tools/scaffold-presenter
+++ b/tools/scaffold-presenter
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Wrapper script for generate-presenter-scaffold.py
+# Usage: ./tools/scaffold-presenter <project> <feature-name>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PYTHON="$SCRIPT_DIR/.venv/bin/python3"
+
+# Check if virtual environment exists
+if [ ! -f "$VENV_PYTHON" ]; then
+    echo "Error: Virtual environment not found at tools/.venv"
+    echo ""
+    echo "Please set up the virtual environment first:"
+    echo "  cd tools"
+    echo "  python3 -m venv .venv"
+    echo "  .venv/bin/pip install -r requirements.txt"
+    echo ""
+    exit 1
+fi
+
+# Run the script with the virtual environment Python
+"$VENV_PYTHON" "$SCRIPT_DIR/generate-presenter-scaffold.py" "$@"


### PR DESCRIPTION
Introduce a generator for creating presenter scaffolds in the DAD E-Class project, along with necessary scripts, a README, and a .gitignore file. This addition streamlines the process of generating view-models, presenters, and React hooks with smart case conversion.