### PR TITLE
feat(api): add health check endpoint for Kubernetes readiness/liveness probes

### DIFF
--- a/apps/cms/src/app/api/ping/route.ts
+++ b/apps/cms/src/app/api/ping/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Health check endpoint for Kubernetes readiness/liveness probes
+ * @returns JSON response with status and timestamp
+ */
+export async function GET() {
+    return NextResponse.json(
+        {
+            message: 'pong',
+            status: 'healthy',
+            timestamp: new Date().toISOString(),
+        },
+        {
+            headers: {
+                'Cache-Control': 'no-store, no-cache, must-revalidate',
+            },
+        }
+    );
+}
+
+/**
+ * HEAD method for health checks (used by some monitoring tools)
+ * @returns Empty response with 200 OK status
+ */
+export async function HEAD() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+    });
+}

--- a/apps/platform/src/app/api/ping/route.ts
+++ b/apps/platform/src/app/api/ping/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Health check endpoint for Kubernetes readiness/liveness probes
+ * @returns JSON response with status and timestamp
+ */
+export async function GET() {
+    return NextResponse.json(
+        {
+            message: 'pong',
+            status: 'healthy',
+            timestamp: new Date().toISOString(),
+        },
+        {
+            headers: {
+                'Cache-Control': 'no-store, no-cache, must-revalidate',
+            },
+        }
+    );
+}
+
+/**
+ * HEAD method for health checks (used by some monitoring tools)
+ * @returns Empty response with 200 OK status
+ */
+export async function HEAD() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+    });
+}


### PR DESCRIPTION
This pull request adds health check endpoints to both the CMS and Platform applications. These endpoints are intended for use with Kubernetes readiness/liveness probes and monitoring tools, providing a simple way to verify the application's health status.

New health check endpoints:

**CMS and Platform API:**
- Added a `GET` endpoint at `/api/ping` that returns a JSON response with a status message, health status, and current timestamp. The response includes headers to prevent caching.
- Added a `HEAD` endpoint at `/api/ping` that returns an empty 200 OK response with appropriate cache-control headers, supporting lightweight health checks by monitoring tools.