### PR TITLE
[TSK-1543] Fix hairpin NAT issue for server-side cms-rest requests

### DIFF
--- a/apps/cms/.env.local.template
+++ b/apps/cms/.env.local.template
@@ -19,6 +19,7 @@ E_CLASS_DEV_MODE="true"
 NEXT_PUBLIC_E_CLASS_RUNTIME="cms"
 NEXT_PUBLIC_APP_URL="https://localhost:3000"
 NEXT_PUBLIC_E_CLASS_CMS_REST_URL="http://localhost:5173"
+E_CLASS_CMS_REST_URL="http://localhost:5173"
 NEXT_PUBLIC_CONTACT_EMAIL="example@mail.com"
 NEXT_PUBLIC_CMS_BACKGROUND_IMAGE_URL="https://example.com/background.jpg"
 

--- a/apps/cms/src/lib/infrastructure/common/utils/get-cms-query-client.ts
+++ b/apps/cms/src/lib/infrastructure/common/utils/get-cms-query-client.ts
@@ -6,8 +6,20 @@ import {
 import superjson from 'superjson';
 import env from '../../client/config/env';
 
+/**
+ * Gets the TRPC URL for cms-rest connections
+ *
+ * For server-side requests:
+ * - In Kubernetes: Uses E_CLASS_CMS_REST_URL (internal cluster URL) to avoid hairpin NAT
+ * - In local dev: Falls back to NEXT_PUBLIC_E_CLASS_CMS_REST_URL (localhost)
+ *
+ * For client-side requests:
+ * - E_CLASS_CMS_REST_URL is not available in browser, so uses NEXT_PUBLIC_E_CLASS_CMS_REST_URL
+ */
 export function getTRPCUrl() {
-    const base = env.NEXT_PUBLIC_E_CLASS_CMS_REST_URL;
+    const base =
+        process.env.E_CLASS_CMS_REST_URL ||
+        env.NEXT_PUBLIC_E_CLASS_CMS_REST_URL;
     return `${base}/api/trpc`;
 }
 

--- a/apps/cms/src/lib/infrastructure/server/config/env.ts
+++ b/apps/cms/src/lib/infrastructure/server/config/env.ts
@@ -11,6 +11,7 @@ const serverEnvSchema = clientEnvSchema.merge(z.object({
     AUTH_AUTH0_AUTHORIZATION_URL: z.string().url(),
     AUTH_ENABLE_TEST_ACCOUNTS: z.boolean(),
     E_CLASS_DEV_MODE: z.boolean(),
+    E_CLASS_CMS_REST_URL: z.string().url().optional(),
     S3_HOSTNAME: z.string().min(1),
     S3_PORT: z.string().min(1),
     S3_PROTOCOL: z.enum(['http', 'https']),
@@ -39,6 +40,7 @@ const runtimeEnv = {
         process.env.AUTH_ENABLE_TEST_ACCOUNTS?.trim().toLowerCase() === 'true',
     E_CLASS_DEV_MODE:
         process.env.E_CLASS_DEV_MODE?.trim().toLowerCase() === 'true',
+    E_CLASS_CMS_REST_URL: process.env.E_CLASS_CMS_REST_URL,
     S3_HOSTNAME: process.env.S3_HOSTNAME || (isBuildTime ? 'localhost' : undefined),
     S3_PORT: process.env.S3_PORT || (isBuildTime ? '9000' : undefined),
     S3_PROTOCOL: process.env.S3_PROTOCOL === 'https' ? 'https' : 'http',

--- a/apps/platform/.env.local.template
+++ b/apps/platform/.env.local.template
@@ -19,6 +19,7 @@ NEXT_PUBLIC_E_CLASS_RUNTIME="eclass-dev"
 NEXT_PUBLIC_E_CLASS_PLATFORM_NAME="E-Class Dev Platform"
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 NEXT_PUBLIC_E_CLASS_CMS_REST_URL="http://localhost:5173"
+E_CLASS_CMS_REST_URL="http://localhost:5173"
 
 # S3/Storage Configuration
 S3_HOSTNAME="localhost"

--- a/apps/platform/src/lib/infrastructure/server/config/env.ts
+++ b/apps/platform/src/lib/infrastructure/server/config/env.ts
@@ -9,6 +9,7 @@ const serverEnvSchema = clientEnvSchema.merge(z.object({
     AUTH_AUTH0_ISSUER: z.string().url(),
     AUTH_AUTH0_AUTHORIZATION_URL: z.string().url(),
     E_CLASS_DEV_MODE: z.boolean(),
+    E_CLASS_CMS_REST_URL: z.string().url().optional(),
     S3_HOSTNAME: z.string().min(1),
     S3_PORT: z.string().min(1),
     S3_PROTOCOL: z.enum(['http', 'https']),
@@ -36,6 +37,7 @@ const runtimeEnv = {
     AUTH_AUTH0_AUTHORIZATION_URL: process.env.AUTH_AUTH0_AUTHORIZATION_URL || (isBuildTime ? 'https://build-time.placeholder.com/authorize' : undefined),
     E_CLASS_DEV_MODE:
         process.env.E_CLASS_DEV_MODE?.trim().toLowerCase() === 'true',
+    E_CLASS_CMS_REST_URL: process.env.E_CLASS_CMS_REST_URL,
     S3_HOSTNAME: process.env.S3_HOSTNAME || (isBuildTime ? 'localhost' : undefined),
     S3_PORT: process.env.S3_PORT || (isBuildTime ? '9000' : undefined),
     S3_PROTOCOL: process.env.S3_PROTOCOL === 'https' ? 'https' : 'http',

--- a/apps/platform/src/lib/infrastructure/server/config/trpc/cms-server.tsx
+++ b/apps/platform/src/lib/infrastructure/server/config/trpc/cms-server.tsx
@@ -64,10 +64,16 @@ async function createServerHeaders(): Promise<Record<string, string>> {
 /**
  * Gets the TRPC URL from runtime environment variables
  * Reads directly from process.env (works because parent called connection())
+ *
+ * For server-side requests:
+ * - In Kubernetes: Uses E_CLASS_CMS_REST_URL (internal cluster URL) to avoid hairpin NAT
+ * - In local dev: Falls back to NEXT_PUBLIC_E_CLASS_CMS_REST_URL (localhost)
  */
 function getTRPCUrl(): string {
     const base =
-        process.env.NEXT_PUBLIC_E_CLASS_CMS_REST_URL || 'http://localhost:5173';
+        process.env.E_CLASS_CMS_REST_URL ||
+        process.env.NEXT_PUBLIC_E_CLASS_CMS_REST_URL ||
+        'http://localhost:5173';
     return `${base}/api/trpc`;
 }
 


### PR DESCRIPTION
## Problem

The platform and cms applications were throwing `TRPCClientError: fetch failed` with `ECONNRESET` errors when making server-side requests to cms-rest in Kubernetes:

```
Error [TRPCClientError]: fetch failed
[cause]: TypeError: fetch failed {
  [cause]: [Error: read ECONNRESET] {
    errno: -104,
    code: 'ECONNRESET',
    syscall: 'read'
  }
}
```

## Root Cause

Both applications were using `NEXT_PUBLIC_E_CLASS_CMS_REST_URL=https://cms-rest.eclasslogin.ch` for **both** server-side and client-side requests. 

When making server-side (SSR/API routes) requests in Kubernetes, the traffic path was:

```
Platform/CMS Pod → External Load Balancer → cms-rest Pod (same cluster)
```

This "hairpin NAT" routing pattern fails because both services are behind the same load balancer, and the network doesn't support loopback through the external LB.

## Solution

Implemented context-aware URL selection using different environment variables:

- **Server-side context** (SSR, API routes, RSC): Uses `E_CLASS_CMS_REST_URL=http://cms-rest.eclass.svc.cluster.local:5173` (internal cluster URL)
- **Client-side context** (browser): Uses `NEXT_PUBLIC_E_CLASS_CMS_REST_URL=https://cms-rest.eclasslogin.ch` (external public URL)

## Changes Made

### Platform App
- **cms-server.tsx**: Updated `getTRPCUrl()` to check `E_CLASS_CMS_REST_URL` first, then fall back to public URL
- **env.ts**: Added `E_CLASS_CMS_REST_URL` to server environment schema (optional)
- **.env.local.template**: Added new environment variable for local development

### CMS App
- **get-cms-query-client.ts**: Updated `getTRPCUrl()` to check `process.env.E_CLASS_CMS_REST_URL` first
- **env.ts**: Added `E_CLASS_CMS_REST_URL` to server environment schema (optional)
- **.env.local.template**: Added new environment variable for local development

## Why Client-Side Still Works

Browser requests to `https://cms-rest.eclasslogin.ch` work fine because they originate from outside the cluster, avoiding the hairpin routing issue entirely.

## Testing

- ✅ Local development: Both URLs point to `localhost:5173`, seamless operation
- ⚠️ Kubernetes: Requires `E_CLASS_CMS_REST_URL` environment variable to be set in deployment (already configured per issue description)
- ✅ Client-side requests: Continue working as before using public URL
- ✅ Server-side requests: Will now use internal cluster URL avoiding ECONNRESET

## Deployment Notes

The `E_CLASS_CMS_REST_URL` environment variable is already configured in the Kubernetes deployment with value `http://cms-rest.eclass.svc.cluster.local:5173`. No additional infrastructure changes needed.