### PR TITLE
Update cms-rest and related dependencies to 2.10.4

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -2,7 +2,7 @@ name: e-class
 
 services:
   cms-fastapi:
-    image: ghcr.io/dream-aim-deliver/e-class-cms-fastapi:2.10.3
+    image: ghcr.io/dream-aim-deliver/e-class-cms-fastapi:2.10.4
     container_name: e-class-cms-fastapi
     command: ["sh", "-c", "pyenv exec poetry run start"]
     depends_on:
@@ -63,7 +63,7 @@ services:
 
 
   cms-rest:
-    image: ghcr.io/dream-aim-deliver/e-class-cms-rest:2.10.3
+    image: ghcr.io/dream-aim-deliver/e-class-cms-rest:2.10.4
     container_name: e-class-cms-rest
     depends_on:
       - cms-fastapi

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@dream-aim-deliver/dad-cats": "^0.13.0",
-    "@dream-aim-deliver/e-class-cms-rest": "2.10.3",
+    "@dream-aim-deliver/e-class-cms-rest": "2.10.4",
     "@mux/mux-player-react": "^3.3.0",
     "@tailwindcss/postcss": "4.0.0-beta.8",
     "@tanstack/react-query": "^5.76.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,7 +16,7 @@
     "next-auth": "5.0.0-beta.25",
     "@maany_shr/e-class-models": "workspace:*",
     "@trpc/client": "^11.1.2",
-    "@dream-aim-deliver/e-class-cms-rest": "2.10.3",
+    "@dream-aim-deliver/e-class-cms-rest": "2.10.4",
     "superjson": "^2.2.2"
   },
   "publishConfig": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "zod": "^3.24.1",
         "@dream-aim-deliver/dad-cats": "^0.13.0",
-        "@dream-aim-deliver/e-class-cms-rest": "2.10.3"
+        "@dream-aim-deliver/e-class-cms-rest": "2.10.4"
     },
     "publishConfig": {
         "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       '@dream-aim-deliver/e-class-cms-rest':
-        specifier: 2.10.3
-        version: 2.10.3(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
+        specifier: 2.10.4
+        version: 2.10.4(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
       '@mux/mux-player-react':
         specifier: ^3.3.0
         version: 3.3.0(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -332,8 +332,8 @@ importers:
   packages/auth:
     dependencies:
       '@dream-aim-deliver/e-class-cms-rest':
-        specifier: 2.10.3
-        version: 2.10.3(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
+        specifier: 2.10.4
+        version: 2.10.4(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
       '@maany_shr/e-class-models':
         specifier: workspace:*
         version: link:../models
@@ -356,8 +356,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       '@dream-aim-deliver/e-class-cms-rest':
-        specifier: 2.10.3
-        version: 2.10.3(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
+        specifier: 2.10.4
+        version: 2.10.4(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)
       zod:
         specifier: ^3.24.1
         version: 3.24.1
@@ -1141,8 +1141,8 @@ packages:
   '@dream-aim-deliver/dad-data-platform-sdk-ts@0.5.7':
     resolution: {integrity: sha512-F+H/ip1hG+Jh4EZo2cFhbYQ+l7S9fZZSDFsqnTnr/63XOTp2/K1CBcNvoi8GMdgux3yKaFFlUb+Ev06ExkIR9g==, tarball: https://npm.pkg.github.com/download/@dream-aim-deliver/dad-data-platform-sdk-ts/0.5.7/8c0f1b22da557615ddb4151df854ab5e491cba56}
 
-  '@dream-aim-deliver/e-class-cms-rest@2.10.3':
-    resolution: {integrity: sha512-YOCD90vZd6yALOcFyPXS5A92i6P9ZjLQ+0cFn7yJWaeHrZ2d5XolIbDgZ075SNPqMXxnEHTBeVBzqKF7noEkUw==, tarball: https://npm.pkg.github.com/download/@dream-aim-deliver/e-class-cms-rest/2.10.3/e2c2a689a186c850432ceb013e0aab00b5df450e}
+  '@dream-aim-deliver/e-class-cms-rest@2.10.4':
+    resolution: {integrity: sha512-qYbFbrvKXtbjoDqULVTN0l1eW3l3yUgMXT6dSRy6wC+nFYuFYIHUCRxfCCzRGPFQezcCmbBl4MZNliB7/yRqLg==, tarball: https://npm.pkg.github.com/download/@dream-aim-deliver/e-class-cms-rest/2.10.4/44ec283d8abe16551e859a07b504defc7fe6183b}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -10363,7 +10363,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@dream-aim-deliver/e-class-cms-rest@2.10.3(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)':
+  '@dream-aim-deliver/e-class-cms-rest@2.10.4(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)':
     dependencies:
       '@dream-aim-deliver/dad-cats': 0.13.0(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       '@dream-aim-deliver/dad-data-platform-sdk-ts': 0.5.7(@types/node@18.16.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
@@ -10403,7 +10403,7 @@ snapshots:
       - terser
       - typescript
 
-  '@dream-aim-deliver/e-class-cms-rest@2.10.3(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)':
+  '@dream-aim-deliver/e-class-cms-rest@2.10.4(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)(typescript@5.7.2)':
     dependencies:
       '@dream-aim-deliver/dad-cats': 0.13.0(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)
       '@dream-aim-deliver/dad-data-platform-sdk-ts': 0.5.7(@types/node@22.17.0)(@vitest/ui@2.1.8)(jsdom@25.0.1)(less@4.1.3)(lightningcss@1.28.2)(sass@1.82.0)(stylus@0.64.0)(terser@5.37.0)


### PR DESCRIPTION
Upgrade the cms-rest service and its dependencies to version 2.10.4 for improved functionality and performance.