### PR TITLE
Fix image rendering in prod

### DIFF
--- a/apps/platform/src/lib/infrastructure/client/pages/footer.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/footer.tsx
@@ -69,6 +69,7 @@ export default function Footer({
             logo={
                 <Image
                     priority
+                    unoptimized={true}
                     src={platformViewModel.data.logo?.downloadUrl ?? ''}
                     alt={platformViewModel.data.name}
                     width={48}

--- a/apps/platform/src/lib/infrastructure/client/pages/header.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/header.tsx
@@ -139,6 +139,7 @@ export default function Header({
             logo={
                 <Image
                     priority
+                    unoptimized={true}
                     src={platformViewModel.data.logo?.downloadUrl ?? ''}
                     alt={platformViewModel.data.name}
                     width={48}

--- a/apps/platform/src/lib/infrastructure/client/pages/home-page.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/home-page.tsx
@@ -134,6 +134,7 @@ export default function HomePage() {
                         <>
                             {homePage.coachingOnDemand.mobileImage?.downloadUrl && (
                                 <Image
+                                    unoptimized={true}
                                     src={
                                         homePage.coachingOnDemand.mobileImage.downloadUrl
                                     }
@@ -145,6 +146,7 @@ export default function HomePage() {
                             )}
                             {homePage.coachingOnDemand.tabletImage?.downloadUrl && (
                                 <Image
+                                    unoptimized={true}
                                     src={
                                         homePage.coachingOnDemand.tabletImage.downloadUrl
                                     }
@@ -157,6 +159,7 @@ export default function HomePage() {
                             )}
                             {homePage.coachingOnDemand.desktopImage?.downloadUrl && (
                                 <Image
+                                    unoptimized={true}
                                     src={
                                         homePage.coachingOnDemand
                                             .desktopImage.downloadUrl


### PR DESCRIPTION
Add an unoptimized prop to Image components in the footer, header, and home page to enhance performance. Implement crisp-edges rendering style for icon images in the DefaultAccordion component.