### PR TITLE
[TSK-1783] fix(platform/analytics): render Usercentrics loader.js in <head> server-side

### DIFF
--- a/apps/platform/src/app/[locale]/(wired-pages)/layout.tsx
+++ b/apps/platform/src/app/[locale]/(wired-pages)/layout.tsx
@@ -34,6 +34,7 @@ import {
     PlatformAnalytics,
     ConsentModeDefaultScript,
     UsercentricsAutoblocker,
+    UsercentricsCMPLoader,
 } from '../../../lib/infrastructure/client/analytics';
 
 type MetadataProps = {
@@ -240,6 +241,10 @@ export default async function RootLayout({
             <head>
                 <UsercentricsAutoblocker
                     settingsId={runtimeConfig.NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID}
+                />
+                <UsercentricsCMPLoader
+                    settingsId={runtimeConfig.NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID}
+                    language={locale}
                 />
                 <ConsentModeDefaultScript />
                 <MobileReadyStyle />

--- a/apps/platform/src/app/[locale]/auth/layout.tsx
+++ b/apps/platform/src/app/[locale]/auth/layout.tsx
@@ -12,6 +12,7 @@ import {
     PlatformAnalytics,
     ConsentModeDefaultScript,
     UsercentricsAutoblocker,
+    UsercentricsCMPLoader,
 } from '../../../lib/infrastructure/client/analytics';
 
 export const metadata = {
@@ -63,6 +64,10 @@ export default async function RootLayout({
             <head>
                 <UsercentricsAutoblocker
                     settingsId={runtimeConfig.NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID}
+                />
+                <UsercentricsCMPLoader
+                    settingsId={runtimeConfig.NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID}
+                    language={locale}
                 />
                 <ConsentModeDefaultScript />
 

--- a/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
@@ -74,54 +74,22 @@ function readUsercentricsState(): TConsentState {
     };
 }
 
-interface TUsercentricsAdapterOptions {
-    /** Settings ID from the Usercentrics dashboard (data-settings-id). */
-    settingsId: string;
-    /**
-     * ISO 639-1 language code (e.g. "de", "en") that the banner and
-     * second-layer UI should render in. Sourced from next-intl's current
-     * locale so the CMP matches the rest of the app. Usercentrics defaults
-     * to `navigator.language` when unset, which mismatches our routed
-     * locale for users whose browser default differs from their URL
-     * (e.g. English-browser user on /de/). Usercentrics falls back to the
-     * dashboard's configured default if this code is not an enabled
-     * language in the dashboard.
-     */
-    language?: string;
-}
-
-const CMP_LOADER_URL = 'https://web.cmp.usercentrics.eu/ui/loader.js';
-
 /**
  * Usercentrics CMP v3 adapter.
  *
- * Injects the CMP loader script. The autoblocker is mounted separately via
- * `<UsercentricsAutoblocker />` in the layouts so it can run with
- * `beforeInteractive` priority — the adapter only handles the main CMP UI
- * and the consent-state translation.
+ * Script mounting is handled server-side by `<UsercentricsCMPLoader>` and
+ * `<UsercentricsAutoblocker>` rendered into `<head>`; this adapter only wires
+ * runtime listeners and translates consent state. Keeping injection out of
+ * client effects eliminates the hydration race (effect-never-runs cases like
+ * bfcache restore, upstream error boundary, cancelled hydration) that
+ * previously caused the banner to flakily not appear.
  *
  * Consent state is read from `window.UC_UI.getServicesBaseInfo()` on every
  * CMP event; the banner is opened via `window.UC_UI.showFirstLayer()`.
  */
-export function createUsercentricsAdapter(
-    options: TUsercentricsAdapterOptions,
-): TConsentAdapter {
+export function createUsercentricsAdapter(): TConsentAdapter {
     return {
         init() {
-            if (typeof document === 'undefined') return;
-            // Idempotent: Usercentrics's loader self-identifies via id="usercentrics-cmp".
-            if (document.getElementById('usercentrics-cmp')) return;
-
-            const script = document.createElement('script');
-            script.id = 'usercentrics-cmp';
-            script.src = CMP_LOADER_URL;
-            script.async = true;
-            script.setAttribute('data-settings-id', options.settingsId);
-            if (options.language) {
-                script.setAttribute('data-language', options.language);
-            }
-            document.head.appendChild(script);
-
             // Hide the persistent floating privacy button ("fingerprint" icon)
             // at runtime. Cookie-settings access is provided via the footer's
             // "Privacy Settings" link (<UsercentricsSecondLayerLink>), so the

--- a/apps/platform/src/lib/infrastructure/client/analytics/index.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/index.ts
@@ -2,6 +2,7 @@ export { track } from './track';
 export { PlatformAnalytics } from './platform-analytics';
 export { ConsentModeDefaultScript } from './consent-mode-default-script';
 export { UsercentricsAutoblocker } from './usercentrics-autoblocker';
+export { UsercentricsCMPLoader } from './usercentrics-cmp-loader';
 export { UsercentricsSecondLayerLink } from './usercentrics-second-layer-link';
 export { useConsent } from './consent/consent-provider';
 export type { TConsentState, TOfferType, TItem } from './types';

--- a/apps/platform/src/lib/infrastructure/client/analytics/platform-analytics.tsx
+++ b/apps/platform/src/lib/infrastructure/client/analytics/platform-analytics.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useLocale } from 'next-intl';
 import { createUsercentricsAdapter } from './consent/usercentrics-adapter';
 import { createNoopAdapter } from './consent/noop-adapter';
 import { ConsentProvider } from './consent/consent-provider';
@@ -36,19 +35,11 @@ interface TPlatformAnalyticsProps {
 export function PlatformAnalytics({ children }: TPlatformAnalyticsProps) {
     const { NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID: settingsId } =
         useRuntimeConfig();
-    // Mirror next-intl's routed locale into the Usercentrics banner so the
-    // CMP language matches the page language. Our language switcher does a
-    // full page navigation (footer.tsx → `window.location.href = newUrl`),
-    // so the adapter is re-created with the fresh locale on every switch —
-    // no runtime UC_UI.changeLanguage() plumbing needed.
-    const locale = useLocale();
 
     const adapter = useMemo(
         () =>
-            settingsId
-                ? createUsercentricsAdapter({ settingsId, language: locale })
-                : createNoopAdapter(),
-        [settingsId, locale],
+            settingsId ? createUsercentricsAdapter() : createNoopAdapter(),
+        [settingsId],
     );
 
     return (

--- a/apps/platform/src/lib/infrastructure/client/analytics/usercentrics-cmp-loader.tsx
+++ b/apps/platform/src/lib/infrastructure/client/analytics/usercentrics-cmp-loader.tsx
@@ -1,0 +1,43 @@
+import Script from 'next/script';
+
+/**
+ * Usercentrics CMP v3 loader script.
+ *
+ * Mirrors the canonical Usercentrics snippet by rendering the loader directly
+ * into <head> with `strategy="beforeInteractive"` so it ships with the initial
+ * HTML. Injecting it server-side eliminates the hydration race that a
+ * client-side `useEffect`-based injection suffers from: if hydration is
+ * delayed, aborted, or skipped (bfcache restore, upstream error boundary,
+ * slow/cancelled chunk), an effect-injected loader never fetches and the
+ * banner never appears.
+ *
+ * The loader reads its tenant configuration from `data-settings-id` and the
+ * banner language from `data-language`; both are set at server-render time
+ * from RuntimeConfig + the routed locale.
+ *
+ * Renders nothing when Usercentrics is not configured for this tenant.
+ */
+interface TUsercentricsCMPLoaderProps {
+    /** If unset, the component renders nothing. */
+    settingsId: string | undefined;
+    /** ISO 639-1 language code (e.g. "de", "en"). */
+    language?: string;
+}
+
+const CMP_LOADER_URL = 'https://web.cmp.usercentrics.eu/ui/loader.js';
+
+export function UsercentricsCMPLoader({
+    settingsId,
+    language,
+}: TUsercentricsCMPLoaderProps) {
+    if (!settingsId) return null;
+    return (
+        <Script
+            id="usercentrics-cmp"
+            src={CMP_LOADER_URL}
+            strategy="beforeInteractive"
+            data-settings-id={settingsId}
+            {...(language ? { 'data-language': language } : {})}
+        />
+    );
+}

--- a/apps/platform/tests/analytics/platform-analytics.test.tsx
+++ b/apps/platform/tests/analytics/platform-analytics.test.tsx
@@ -44,55 +44,7 @@ describe('PlatformAnalytics', () => {
         expect(screen.getByTestId('child')).toBeDefined();
     });
 
-    it('does NOT inject the Usercentrics loader when settings ID is unset', () => {
-        render(
-            <NextIntlClientProvider locale="en" messages={{}}>
-                <RuntimeConfigProvider config={baseConfig()}>
-                    <PlatformAnalytics>
-                        <span />
-                    </PlatformAnalytics>
-                </RuntimeConfigProvider>
-            </NextIntlClientProvider>,
-        );
-        expect(document.getElementById('usercentrics-cmp')).toBeNull();
-    });
-
-    it('injects the Usercentrics loader when settings ID is set', () => {
-        const config = {
-            ...baseConfig(),
-            NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID: 'qYcjvyqjEYm8kA',
-        };
-        render(
-            <NextIntlClientProvider locale="en" messages={{}}>
-                <RuntimeConfigProvider config={config}>
-                    <PlatformAnalytics>
-                        <span />
-                    </PlatformAnalytics>
-                </RuntimeConfigProvider>
-            </NextIntlClientProvider>,
-        );
-        const script = document.getElementById('usercentrics-cmp') as HTMLScriptElement | null;
-        expect(script).not.toBeNull();
-        expect(script!.getAttribute('data-settings-id')).toBe('qYcjvyqjEYm8kA');
-        expect(script!.src).toBe('https://web.cmp.usercentrics.eu/ui/loader.js');
-    });
-
-    it('passes the locale as data-language on the Usercentrics loader script', () => {
-        const config = {
-            ...baseConfig(),
-            NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID: 'qYcjvyqjEYm8kA',
-        };
-        render(
-            <NextIntlClientProvider locale="de" messages={{}}>
-                <RuntimeConfigProvider config={config}>
-                    <PlatformAnalytics>
-                        <span />
-                    </PlatformAnalytics>
-                </RuntimeConfigProvider>
-            </NextIntlClientProvider>,
-        );
-        const script = document.getElementById('usercentrics-cmp') as HTMLScriptElement | null;
-        expect(script).not.toBeNull();
-        expect(script!.getAttribute('data-language')).toBe('de');
-    });
+    // Loader-script injection is the responsibility of <UsercentricsCMPLoader>
+    // rendered in the root layouts — see usercentrics-cmp-loader.test.tsx.
+    // PlatformAnalytics itself only composes the Consent/Analytics providers.
 });

--- a/apps/platform/tests/analytics/usercentrics-adapter.test.ts
+++ b/apps/platform/tests/analytics/usercentrics-adapter.test.ts
@@ -32,27 +32,14 @@ describe('usercentrics-adapter', () => {
         delete (window as Window).UC_UI;
     });
 
-    it('init() injects the canonical Usercentrics CMP loader script', () => {
-        const adapter = createUsercentricsAdapter({ settingsId: 'qYcjvyqjEYm8kA' });
+    it('init() does not inject the loader script (now rendered server-side in <head>)', () => {
+        const adapter = createUsercentricsAdapter();
         adapter.init();
-
-        const script = document.getElementById('usercentrics-cmp') as HTMLScriptElement | null;
-        expect(script).not.toBeNull();
-        expect(script!.tagName).toBe('SCRIPT');
-        expect(script!.src).toBe('https://web.cmp.usercentrics.eu/ui/loader.js');
-        expect(script!.getAttribute('data-settings-id')).toBe('qYcjvyqjEYm8kA');
-        expect(script!.async).toBe(true);
-    });
-
-    it('init() does not inject twice on repeat calls', () => {
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc123xyz000' });
-        adapter.init();
-        adapter.init();
-        expect(document.querySelectorAll('script#usercentrics-cmp').length).toBe(1);
+        expect(document.getElementById('usercentrics-cmp')).toBeNull();
     });
 
     it('onConsentChange fires handler immediately with denied state when UC_UI is not loaded', () => {
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
         expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
@@ -69,7 +56,7 @@ describe('usercentrics-adapter', () => {
             ],
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
         expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
@@ -87,7 +74,7 @@ describe('usercentrics-adapter', () => {
             getServicesBaseInfo: () => Promise.resolve([]),
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         expect(() => adapter.onConsentChange(handler)).not.toThrow();
         expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
@@ -103,7 +90,7 @@ describe('usercentrics-adapter', () => {
             ],
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
         handler.mockClear();
@@ -125,7 +112,7 @@ describe('usercentrics-adapter', () => {
             ],
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
         handler.mockClear();
@@ -146,7 +133,7 @@ describe('usercentrics-adapter', () => {
             ],
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
         handler.mockClear();
@@ -163,7 +150,7 @@ describe('usercentrics-adapter', () => {
             ],
         };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         const unsubscribe = adapter.onConsentChange(handler);
         handler.mockClear();
@@ -177,13 +164,13 @@ describe('usercentrics-adapter', () => {
         const showFirstLayer = vi.fn();
         window.UC_UI = { showFirstLayer };
 
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         adapter.showBanner();
         expect(showFirstLayer).toHaveBeenCalledTimes(1);
     });
 
     it('showBanner() is a no-op if UC_UI is not loaded yet', () => {
-        const adapter = createUsercentricsAdapter({ settingsId: 'abc' });
+        const adapter = createUsercentricsAdapter();
         expect(() => adapter.showBanner()).not.toThrow();
     });
 });

--- a/apps/platform/tests/analytics/usercentrics-cmp-loader.test.tsx
+++ b/apps/platform/tests/analytics/usercentrics-cmp-loader.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { UsercentricsCMPLoader } from '../../src/lib/infrastructure/client/analytics/usercentrics-cmp-loader';
+
+vi.mock('next/script', () => ({
+    default: (props: Record<string, unknown>) => {
+        const { strategy: _strategy, ...rest } = props as { strategy?: string } & Record<string, unknown>;
+        void _strategy;
+        return <script {...(rest as Record<string, unknown>)} />;
+    },
+}));
+
+describe('UsercentricsCMPLoader', () => {
+    it('renders nothing when settingsId is undefined', () => {
+        const html = renderToStaticMarkup(<UsercentricsCMPLoader settingsId={undefined} />);
+        expect(html).toBe('');
+    });
+
+    it('renders the loader script with settings and language when set', () => {
+        const html = renderToStaticMarkup(
+            <UsercentricsCMPLoader settingsId="qYcjvyqjEYm8kA" language="de" />,
+        );
+        expect(html).toContain('id="usercentrics-cmp"');
+        expect(html).toContain('src="https://web.cmp.usercentrics.eu/ui/loader.js"');
+        expect(html).toContain('data-settings-id="qYcjvyqjEYm8kA"');
+        expect(html).toContain('data-language="de"');
+    });
+
+    it('omits data-language when language is not provided', () => {
+        const html = renderToStaticMarkup(
+            <UsercentricsCMPLoader settingsId="abc123" />,
+        );
+        expect(html).toContain('data-settings-id="abc123"');
+        expect(html).not.toContain('data-language');
+    });
+});


### PR DESCRIPTION
## Issue

On `eclass.justdoad.ch` the Usercentrics consent banner flakily failed to appear. Evidence from prod:

- `loader.js` (`https://web.cmp.usercentrics.eu/ui/loader.js`) intermittently did not show up in the Network tab.
- When `loader.js` was missing, the banner never rendered and `window.UC_UI` was undefined.
- Toggling DevTools **Disable cache** (which also disables bfcache) reliably made the banner reappear.
- Prior fixes (`20de57ace`, `e6c7d80ea`, `925db1738`) hardened various edges but did not address the structural cause.

## Root cause

`loader.js` was injected client-side by `adapter.init()` inside a `useEffect` in `ConsentProvider`:

```ts
useEffect(() => {
  adapter.init();                 // appends <script src=".../loader.js">
  const unsub = adapter.onConsentChange(...);
  return unsub;
}, [adapter]);
```

The banner therefore depended on a successful React hydration cycle. Any case where the effect did not fire — bfcache restore, an upstream error boundary, a cancelled/slow hydration — left `loader.js` unfetched and the banner absent. This matches the "Disable cache makes it work" observation exactly: Disable cache disables bfcache and forces a clean reload, so the effect always runs.

The canonical Usercentrics v3 snippet places `loader.js` directly in `<head>` alongside the autoblocker; our implementation diverged from that.

## Fix

Move `loader.js` injection into the server-rendered `<head>`, next to the autoblocker:

- New `<UsercentricsCMPLoader>` component renders `<script id="usercentrics-cmp" src=".../loader.js" data-settings-id data-language>` with `strategy="beforeInteractive"`.
- Mounted in both root layouts (`[locale]/auth/layout.tsx`, `[locale]/(wired-pages)/layout.tsx`) inside `<head>`, ahead of `<ConsentModeDefaultScript />` and after `<UsercentricsAutoblocker />`.
- `createUsercentricsAdapter()` no longer injects a script or takes `settingsId`/`language`; it only wires `UC_UI_INITIALIZED` / `UC_UI_CMP_EVENT` listeners and translates consent state.
- `PlatformAnalytics` drops `useLocale()` — locale is passed server-side via the route param to the loader component.

With the loader in the initial HTML, the banner no longer depends on hydration completing, eliminating the bfcache / aborted-hydration failure modes.

## Tests

- `usercentrics-cmp-loader.test.tsx` (new, 3 tests): renders nothing without `settingsId`; emits `data-settings-id` and `data-language`; omits `data-language` when absent.
- `usercentrics-adapter.test.ts`: updated for the no-arg factory; removed the two "init injects script" assertions (now covered by the loader test), added an assertion that `init()` does NOT inject.
- `platform-analytics.test.tsx`: removed loader-injection assertions; kept the "renders children" base test.

## Verification after deploy

Confirm the RSC payload includes both entries in `<head>`:

```bash
curl -s https://eclass.justdoad.ch/en | grep -oE '"id":"usercentrics-(cmp|autoblocker)"'
```

Expect both `usercentrics-autoblocker` and `usercentrics-cmp` present. In the browser, `loader.js` should appear on first load and after back/forward navigation with the cache enabled.

## Test plan

- [ ] Fresh load (cache enabled): banner appears, `loader.js` in Network
- [ ] Back/forward navigation: banner still available, `UC_UI` present
- [ ] Cache disabled: identical behavior (no longer needed as a workaround)
- [ ] `/en` and `/de`: `data-language` reflects the routed locale
- [ ] Tenant with no `NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID`: nothing rendered, no broken UI
- [ ] Footer "Privacy Settings" link still opens the second layer