### PR TITLE
Update navbar logo link to use dynamic URL based on locale

### DIFF
--- a/apps/platform/.env.local.template
+++ b/apps/platform/.env.local.template
@@ -49,3 +49,5 @@ NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID=""
 # Google Search Console site-verification token (meta-tag method).
 # Per-tenant. Leave empty if the tenant's GSC property is not verified yet.
 NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=""
+
+NEXT_PUBLIC_LOGO_HREF=""

--- a/apps/platform/src/lib/infrastructure/client/pages/footer.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/footer.tsx
@@ -86,6 +86,7 @@ export default function Footer({
         <FooterComponent
             availableLocales={availableLocales}
             locale={locale}
+            logoHref={process.env.NEXT_PUBLIC_LOGO_HREF ? `${process.env.NEXT_PUBLIC_LOGO_HREF}/${locale}` : '/'}
             logo={
                 platformViewModel.data.logo?.downloadUrl ? (
                     <Image

--- a/apps/platform/src/lib/infrastructure/client/pages/header.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/header.tsx
@@ -170,6 +170,7 @@ export default function Header({
             isLoggedIn={!!session}
             availableLocales={availableLocales}
             locale={locale}
+            logoHref={process.env.NEXT_PUBLIC_LOGO_HREF ? `${process.env.NEXT_PUBLIC_LOGO_HREF}/${locale}` : '/'}
             onLogin={handleLogin}
             logo={
                 platformViewModel.data.logo?.downloadUrl ? (

--- a/packages/ui-kit/lib/components/footer.tsx
+++ b/packages/ui-kit/lib/components/footer.tsx
@@ -10,6 +10,7 @@ interface FooterProps extends isLocalAware {
     children?: React.ReactNode;
     footerChildren?: React.ReactNode;
     availableLocales: TLocale[];
+    logoHref?: string;
 }
 
 /**
@@ -47,6 +48,7 @@ export const Footer: React.FC<FooterProps> = ({
     children,
     footerChildren,
     availableLocales,
+    logoHref = '/',
 }) => {
     const ImageComponent = useImageComponent();
 
@@ -71,7 +73,7 @@ export const Footer: React.FC<FooterProps> = ({
                     <div className="flex justify-between items-start">
                         {/* Logo (Left) */}
                         <div className="w-1/2">
-                            <a href="/" className="block h-12 w-fit">
+                            <a href={logoHref} className="block h-12 w-fit">
                                 {logo}
                                 {logoSrc && (
                                     <ImageComponent
@@ -125,7 +127,7 @@ export const Footer: React.FC<FooterProps> = ({
                 <div className="hidden py-6 lg:flex flex-row justify-between items-start lg:items-center">
                     {/* Left Section: Logo Only */}
                     <div className="mb-6 lg:mb-0">
-                        <a href="/" className="block h-12 w-fit">
+                        <a href={logoHref} className="block h-12 w-fit">
                             {logo}
                             {logoSrc && (
                                 <ImageComponent

--- a/packages/ui-kit/lib/components/navbar.tsx
+++ b/packages/ui-kit/lib/components/navbar.tsx
@@ -32,6 +32,7 @@ interface NavbarProps extends isLocalAware {
   dropdownTriggerText?: string;
   onNotificationClick?: () => void;
   onMobileWorkspaceTriggerClick?: () => void;
+  logoHref?: string;
 }
 
 interface NavBarDropdownProps {
@@ -178,11 +179,11 @@ export const Navbar: React.FC<NavbarProps> = ({
   dropdownTriggerText = '',
   onNotificationClick,
   onMobileWorkspaceTriggerClick,
+  logoHref = '/',
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const dictionary = getDictionary(locale);
   const ImageComponent = useImageComponent();
-  const logoHref = `https://www.justdoad.ai/${locale}`;
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);

--- a/packages/ui-kit/lib/components/navbar.tsx
+++ b/packages/ui-kit/lib/components/navbar.tsx
@@ -182,6 +182,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const dictionary = getDictionary(locale);
   const ImageComponent = useImageComponent();
+  const logoHref = `https://www.justdoad.ai/${locale}`;
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -228,7 +229,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   };
 
   const renderLogoLink = () => (
-    <a href="/" className="block h-12">
+    <a href={logoHref} className="block h-12">
       {logo}
       {logoSrc && (
         <img


### PR DESCRIPTION
This pull request updates the `Navbar` component to ensure that the logo link directs users to a locale-specific homepage URL instead of always linking to the root path. The main changes are:

Navigation link update:

* The `logoHref` variable is introduced to dynamically generate the homepage URL based on the current `locale`, ensuring users are directed to the correct language-specific site.
* The logo link's `href` attribute is updated to use the new `logoHref` variable, replacing the previous hardcoded root path (`"/"`).