### PR TITLE
Coaches with a private profile no longer appear in the "add coach to a course"

### DIFF
--- a/apps/platform/src/lib/infrastructure/client/pages/course/enrolled-course/enrolled-coaches.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/course/enrolled-course/enrolled-coaches.tsx
@@ -72,6 +72,7 @@ function EnrolledCoachesContent(props: EnrolledCoachesProps) {
         });
 
     const [availableCoachesResponse] = trpc.listCoaches.useSuspenseQuery({
+        publicCoaches: false,
     });
 
     // Set up presenter for transforming the response to view model


### PR DESCRIPTION
## Problem
Coaches with a private profile ("Privates Profil" checked) no longer appear in the
"add coach to a course" modal, so they can't be assigned. Regression, this used to work.

## Root cause
`b5be4bd4` (2025-12-01) introduced the public-vs-all split in `listCoaches`
(`publicCoaches`). The add-coach query in `enrolled-coaches.tsx` still calls
`listCoaches({})` with no flag, so it now defaults to public-only and filters private
profiles out. `0933e599` (2025-12-14) fixed the coaching page but not this modal.

## Fix
Pass `publicCoaches: false` when loading available coaches for the add-coach modal.
Private profiles stay assignable internally; public coach listings are unaffected.

## Scope
- One query call changed (add-coach modal).
- No changes to public pages, profile settings, or `hideAsCoach`.
- Already-assigned coaches (courseSlug query) untouched.

## How to verify
1. Set a coach's profile to private.
2. As admin, open a course and try to add that coach.
3. Before: coach is missing from the list. After: coach appears and can be assigned.

## Note
No automated test added yet. Happy to add a regression test if you'd prefer.