### PR TITLE
Re-add student role check to pre-course assessment gate

### DIFF
--- a/apps/platform/src/app/[locale]/(wired-pages)/courses/[slug]/page.tsx
+++ b/apps/platform/src/app/[locale]/(wired-pages)/courses/[slug]/page.tsx
@@ -69,8 +69,8 @@ async function handlePCALocaleRedirect(locale: TLocale, slug: string): Promise<v
     await presenter.present(courseAccessResponse, courseAccessViewModel);
 
     if (courseAccessViewModel?.mode === 'default') {
-        const { isAssessmentCompleted, course } = courseAccessViewModel.data;
-        const shouldShowAssessment = isAssessmentCompleted === false;
+        const { isAssessmentCompleted, course, highestRole } = courseAccessViewModel.data;
+        const shouldShowAssessment = highestRole === 'student' && isAssessmentCompleted === false;
 
         if (shouldShowAssessment) {
             const courseLanguage = course?.language?.code as TLocale;

--- a/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
@@ -115,7 +115,7 @@ export default async function CourseServerComponent({
     // Normalize superadmin→admin for all downstream components (same privileges in UI)
     const currentRole = rawRole === 'superadmin' ? 'admin' : rawRole;
 
-    if (shouldShowAssessment(isAssessmentCompleted)) {
+    if (shouldShowAssessment(currentRole, isAssessmentCompleted)) {
         const courseLanguage = course?.language?.code as TLocale;
         return renderAssessmentForm(slug, courseLanguage);
     }
@@ -190,8 +190,8 @@ function validateCourseVisibility(
     }
 }
 
-function shouldShowAssessment(isAssessmentCompleted: boolean | null | undefined): boolean {
-    return isAssessmentCompleted === false;
+function shouldShowAssessment(currentRole: string, isAssessmentCompleted: boolean | null | undefined): boolean {
+    return currentRole === 'student' && isAssessmentCompleted === false;
 }
 
 async function renderAssessmentForm(slug: string, courseLanguage?: TLocale) {


### PR DESCRIPTION
This pull request updates the logic for displaying the assessment form in course pages to ensure that only users with the "student" role who have not completed the assessment will see it. Previously, the assessment form could be shown to any user who hadn't completed the assessment, regardless of their role.

**Assessment form display logic update:**

* Changed the `shouldShowAssessment` function to require both `currentRole === 'student'` and `isAssessmentCompleted === false` before showing the assessment form, preventing non-students from seeing the form.
* Updated the usage of `shouldShowAssessment` in the course server component to pass in the user's role as an argument, ensuring the new logic is applied.
* Modified the locale redirect handler to check `highestRole === 'student'` before showing the assessment, aligning with the new logic. ([apps/platform/src/app/[locale]/(wired-pages)/courses/[slug]/page.tsxL72-R73](diffhunk://#diff-425be3ece9404bfce074abfe7bae3ff27c8d21b3e0c0e197116c78ead66f1721L72-R73))