### PR TITLE
fix(platform/analytics): consent-mode hardening + live audit (root cause was CMP config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ storybook-static
 vitest.config.*.timestamp*
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+# Playwright scratch output (consent audit + e2e runs)
+test-results/
+playwright-report/

--- a/apps/platform-e2e/consent-audit-results/README.md
+++ b/apps/platform-e2e/consent-audit-results/README.md
@@ -1,0 +1,67 @@
+# Consent Mode audit results
+
+Saved output from `../src/consent-audit.spec.ts` — evidence that tracking
+consent is (or is no longer) granted before a visitor touches the cookie
+banner, on both production sites.
+
+## Running
+
+```bash
+AUDIT_LABEL=before-fix pnpm exec playwright test -c apps/platform-e2e/consent-audit.config.ts
+```
+
+Each run writes two files per label:
+
+- `consent-audit-<label>.json` — full machine-readable observation
+- `consent-audit-<label>.md` — human-readable report to share
+
+`AUDIT_LABEL` names the run. Use `before-fix` / `after-fix` so the two are
+directly diffable:
+
+```bash
+diff consent-audit-before-fix.md consent-audit-after-fix.md
+```
+
+## What "fixed" looks like
+
+The suite fails today. After the Usercentrics change, all three assertions
+should pass on both sites:
+
+| Check | Broken (now) | Fixed |
+| --- | --- | --- |
+| Non-essential services granted pre-click | 7 | 0 |
+| Granted `gtag` consent updates pre-click | 2–3 | 0 |
+| GA4 hits above `gcs=G100` pre-click | 1–2 | 0 |
+| Verdict | FAIL ❌ | PASS ✅ |
+
+## Baseline: `before-fix` (2026-08-03)
+
+Both sites load the **same** Usercentrics configuration `jnaPMX-WDaJ4Ig`, so one
+dashboard change affects both.
+
+| Site | Pre-click result |
+| --- | --- |
+| justdoad.ai (Wix) | `G100` → **`G101`** — analytics granted, no click |
+| eclass.justdoad.ch (Next.js) | `G100` → **`G101`** → **`G111`** — analytics + ads granted, no click |
+
+The same 7 non-essential services are pre-granted (`type: IMPLICIT`) on both:
+Google Analytics, Google Ads, Google Tag Manager, DoubleClick Ad, LinkedIn
+Insight Tag, LinkedIn Plugin, YouTube Video.
+
+The shared `G101` comes from the Usercentrics GTM template acting on implicit
+consent; the additional `G111` on eclass is the app's own consent bridge
+escalating it to ad consent. **Both sites are affected** — the Wix site is not
+clean, so the defect is not specific to the Next.js integration.
+
+## Caveats
+
+- **Pre-click only.** A passing run proves nothing is granted *before* the
+  banner is touched. It does not verify that consent correctly turns *on* after
+  a real Accept — that needs a separate interaction phase.
+- **Bot detection matters.** Usercentrics serves a permissive config to headless
+  automation (`isBot=true`) under which everything reports as accepted. The
+  suite spoofs a normal browser fingerprint and asserts the bot config was not
+  served; if that evasion ever breaks, the run fails loudly rather than
+  reporting a false all-clear.
+- Results depend on live third-party infrastructure and on the CMP dashboard, so
+  this suite is deliberately excluded from CI.

--- a/apps/platform-e2e/consent-audit-results/README.md
+++ b/apps/platform-e2e/consent-audit-results/README.md
@@ -53,6 +53,32 @@ consent; the additional `G111` on eclass is the app's own consent bridge
 escalating it to ad consent. **Both sites are affected** — the Wix site is not
 clean, so the defect is not specific to the Next.js integration.
 
+## Granular consent (2026-08-03) — two app-side bugs, fix not yet deployed
+
+The granular test drives the CMP's second layer, accepts **only Google
+Analytics**, and saves. Measured on eclass.justdoad.ch:
+
+| Source | Consent update pushed |
+| --- | --- |
+| Usercentrics GTM template | `analytics_storage: granted`, all ad signals **denied** ✅ |
+| **our app** | `ad_storage`, `ad_user_data`, `ad_personalization` **granted** ❌ |
+
+Plus **13 OpenTelemetry collector posts** after saving, for a service the user
+had explicitly refused.
+
+Two distinct defects, both app-side, both invisible to Accept-All / Deny-All:
+
+1. **Advertising consent from an analytics-only choice.** Google Analytics is
+   filed under `marketing` in this tenant's dashboard, so accepting it alone
+   flipped the whole marketing category and every ad signal with it. The
+   Usercentrics template handled the same case correctly, which is what
+   identified the app as the source.
+2. **Telemetry for a refused service.** OpenTelemetry was gated on the
+   `analytics` category rather than on its own service.
+
+Both are fixed in PR #702. **This test will keep failing against production
+until that PR is deployed** — it is measuring the live site, not the branch.
+
 ## Run this on a schedule
 
 This suite is the only safeguard that catches the original incident class. The

--- a/apps/platform-e2e/consent-audit-results/README.md
+++ b/apps/platform-e2e/consent-audit-results/README.md
@@ -53,6 +53,21 @@ consent; the additional `G111` on eclass is the app's own consent bridge
 escalating it to ad consent. **Both sites are affected** — the Wix site is not
 clean, so the defect is not specific to the Next.js integration.
 
+## Run this on a schedule
+
+This suite is the only safeguard that catches the original incident class. The
+app-side guard warns when `window.__ucCmp` is *absent*, but the incident was a
+*misconfigured* CMP — services reporting consent the user never gave — which no
+client-side warning detects.
+
+Because it is deliberately excluded from CI (it depends on live third-party
+infrastructure), nothing runs it automatically. Run it:
+
+- after any change to the Usercentrics dashboard — service categories, new
+  services, consent-required regions;
+- after any Usercentrics CMP version bump;
+- otherwise periodically, e.g. monthly, saved under a dated `AUDIT_LABEL`.
+
 ## Caveats
 
 - **Pre-click only.** A passing run proves nothing is granted *before* the

--- a/apps/platform-e2e/consent-audit-results/consent-audit-after-fix.json
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-after-fix.json
@@ -1,0 +1,378 @@
+{
+  "label": "after-fix",
+  "takenAt": "2026-08-03T13:33:45.252Z",
+  "sites": [
+    {
+      "site": "justdoad.ai (Wix)",
+      "url": "https://www.justdoad.ai/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "ALL_DENIED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          }
+        ]
+      }
+    },
+    {
+      "site": "eclass.justdoad.ch (Next.js)",
+      "url": "https://eclass.justdoad.ch/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "ALL_DENIED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [
+          {
+            "analytics_storage": "denied",
+            "ad_storage": "denied",
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "personalization_storage": "denied"
+          },
+          {
+            "analytics_storage": "denied",
+            "ad_storage": "denied",
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "personalization_storage": "denied"
+          },
+          {
+            "analytics_storage": "denied",
+            "ad_storage": "denied",
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "personalization_storage": "denied"
+          }
+        ],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "scroll"
+          },
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/platform-e2e/consent-audit-results/consent-audit-after-fix.md
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-after-fix.md
@@ -1,0 +1,56 @@
+# Consent Mode audit — `after-fix`
+
+Taken: 2026-08-03T13:33:45.252Z
+
+A first-time visitor who has NOT touched the cookie banner must have no
+tracking consent: no non-essential service granted, no granted `gtag`
+consent update, and every GA4 hit at `gcs=G100`.
+
+## justdoad.ai (Wix)
+
+- URL: https://www.justdoad.ai/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `ALL_DENIED`
+- **verdict: PASS ✅**
+
+### Non-essential services granted before any click (0)
+
+_None — correct._
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| page_view | ✅ G100 (both denied — correct before consent) |
+
+### Granted consent updates pushed pre-click (0)
+
+_None — correct._
+
+## eclass.justdoad.ch (Next.js)
+
+- URL: https://eclass.justdoad.ch/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `ALL_DENIED`
+- **verdict: PASS ✅**
+
+### Non-essential services granted before any click (0)
+
+_None — correct._
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| scroll | ✅ G100 (both denied — correct before consent) |
+| page_view | ✅ G100 (both denied — correct before consent) |
+
+### Granted consent updates pushed pre-click (0)
+
+_None — correct._
+
+## Shared configuration
+
+Both sites load the same Usercentrics configuration `jnaPMX-WDaJ4Ig`, so one dashboard change affects both.

--- a/apps/platform-e2e/consent-audit-results/consent-audit-before-fix.json
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-before-fix.json
@@ -1,0 +1,415 @@
+{
+  "label": "before-fix",
+  "takenAt": "2026-08-03T13:10:45.672Z",
+  "sites": [
+    {
+      "site": "justdoad.ai (Wix)",
+      "url": "https://www.justdoad.ai/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "SOME_ACCEPTED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [
+          {
+            "ad_storage": "denied",
+            "ad_personalization": "denied",
+            "ad_user_data": "denied",
+            "analytics_storage": "granted"
+          },
+          {
+            "ad_storage": "denied",
+            "ad_personalization": "denied",
+            "ad_user_data": "denied",
+            "analytics_storage": "granted"
+          }
+        ],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          },
+          {
+            "gcs": "G101",
+            "event": "user_engagement"
+          }
+        ]
+      }
+    },
+    {
+      "site": "eclass.justdoad.ch (Next.js)",
+      "url": "https://eclass.justdoad.ch/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "SOME_ACCEPTED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": true,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [
+          {
+            "ad_storage": "denied",
+            "ad_personalization": "denied",
+            "ad_user_data": "denied",
+            "analytics_storage": "granted"
+          },
+          {
+            "analytics_storage": "denied",
+            "ad_storage": "denied",
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "personalization_storage": "denied"
+          },
+          {
+            "analytics_storage": "denied",
+            "ad_storage": "denied",
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "personalization_storage": "denied"
+          },
+          {
+            "ad_storage": "denied",
+            "ad_personalization": "denied",
+            "ad_user_data": "denied",
+            "analytics_storage": "granted"
+          },
+          {
+            "analytics_storage": "granted",
+            "ad_storage": "granted",
+            "ad_user_data": "granted",
+            "ad_personalization": "granted",
+            "personalization_storage": "granted"
+          }
+        ],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "scroll"
+          },
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          },
+          {
+            "gcs": "G101",
+            "event": "user_engagement"
+          },
+          {
+            "gcs": "G111",
+            "event": "user_engagement"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/platform-e2e/consent-audit-results/consent-audit-before-fix.md
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-before-fix.md
@@ -1,0 +1,78 @@
+# Consent Mode audit — `before-fix`
+
+Taken: 2026-08-03T13:10:45.672Z
+
+A first-time visitor who has NOT touched the cookie banner must have no
+tracking consent: no non-essential service granted, no granted `gtag`
+consent update, and every GA4 hit at `gcs=G100`.
+
+## justdoad.ai (Wix)
+
+- URL: https://www.justdoad.ai/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `SOME_ACCEPTED`
+- **verdict: FAIL ❌**
+
+### Non-essential services granted before any click (7)
+
+| Service | Category | Consent type |
+| --- | --- | --- |
+| DoubleClick Ad | marketing | IMPLICIT |
+| Google Ads | marketing | IMPLICIT |
+| Google Analytics | marketing | IMPLICIT |
+| Google Tag Manager | marketing | IMPLICIT |
+| LinkedIn Insight Tag | marketing | IMPLICIT |
+| LinkedIn Plugin | functional | IMPLICIT |
+| YouTube Video | functional | IMPLICIT |
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| page_view | ✅ G100 (both denied — correct before consent) |
+| user_engagement | ❌ G101 (analytics_storage GRANTED) |
+
+### Granted consent updates pushed pre-click (2)
+
+- `{"ad_storage":"denied","ad_personalization":"denied","ad_user_data":"denied","analytics_storage":"granted"}`
+- `{"ad_storage":"denied","ad_personalization":"denied","ad_user_data":"denied","analytics_storage":"granted"}`
+
+## eclass.justdoad.ch (Next.js)
+
+- URL: https://eclass.justdoad.ch/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `SOME_ACCEPTED`
+- **verdict: FAIL ❌**
+
+### Non-essential services granted before any click (7)
+
+| Service | Category | Consent type |
+| --- | --- | --- |
+| DoubleClick Ad | marketing | IMPLICIT |
+| Google Ads | marketing | IMPLICIT |
+| Google Analytics | marketing | IMPLICIT |
+| Google Tag Manager | marketing | IMPLICIT |
+| LinkedIn Insight Tag | marketing | IMPLICIT |
+| LinkedIn Plugin | functional | IMPLICIT |
+| YouTube Video | functional | IMPLICIT |
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| scroll | ✅ G100 (both denied — correct before consent) |
+| page_view | ✅ G100 (both denied — correct before consent) |
+| user_engagement | ❌ G101 (analytics_storage GRANTED) |
+| user_engagement | ❌ G111 (analytics + ad storage GRANTED) |
+
+### Granted consent updates pushed pre-click (3)
+
+- `{"ad_storage":"denied","ad_personalization":"denied","ad_user_data":"denied","analytics_storage":"granted"}`
+- `{"ad_storage":"denied","ad_personalization":"denied","ad_user_data":"denied","analytics_storage":"granted"}`
+- `{"analytics_storage":"granted","ad_storage":"granted","ad_user_data":"granted","ad_personalization":"granted","personalization_storage":"granted"}`
+
+## Shared configuration
+
+Both sites load the same Usercentrics configuration `jnaPMX-WDaJ4Ig`, so one dashboard change affects both.

--- a/apps/platform-e2e/consent-audit.config.ts
+++ b/apps/platform-e2e/consent-audit.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the LIVE consent audit (`src/consent-audit.spec.ts`).
+ *
+ * Deliberately separate from `playwright.config.ts`:
+ *   - No `webServer`: this suite audits the DEPLOYED public sites
+ *     (justdoad.ai and eclass.justdoad.ch), not a local dev build.
+ *   - No `baseURL`: each test navigates to an absolute production URL.
+ *
+ * NOT part of CI. It depends on live third-party infrastructure (Usercentrics
+ * CDN, Google Tag Manager) and on the client's CMP dashboard configuration, so
+ * a failure here is a finding about production config — not a broken build.
+ *
+ * Run:
+ *   pnpm exec playwright test -c apps/platform-e2e/consent-audit.config.ts
+ */
+export default defineConfig({
+    testDir: './src',
+    testMatch: /consent-audit\.spec\.ts/,
+    // Live third-party CDNs + GTM need generous time to settle.
+    timeout: 90_000,
+    expect: { timeout: 30_000 },
+    // Serial: these assert on real network traffic; parallel runs make the
+    // console report interleave and harder to hand to a client.
+    workers: 1,
+    fullyParallel: false,
+    retries: 0,
+    reporter: [['list']],
+    use: {
+        ...devices['Desktop Chrome'],
+        // Swiss visitor — this is a revDSG question, and Usercentrics decides
+        // consent enforcement partly by region.
+        locale: 'de-CH',
+        timezoneId: 'Europe/Zurich',
+        trace: 'off',
+    },
+    projects: [{ name: 'consent-audit' }],
+});

--- a/apps/platform-e2e/src/consent-audit.spec.ts
+++ b/apps/platform-e2e/src/consent-audit.spec.ts
@@ -584,6 +584,173 @@ test.describe('Consent Mode audit — no tracking consent before the user clicks
         });
     }
 
+    /**
+     * GRANULAR CONSENT — accepting one service must not grant others.
+     *
+     * The two tests above only exercise Accept-All and Deny-All, which is why
+     * both category-proxy bugs reached production unnoticed. This drives the
+     * CMP's second layer, enables ONLY Google Analytics, and saves.
+     *
+     * Measured on eclass.justdoad.ch before the fix, with GA the sole accepted
+     * service:
+     *   - the app pushed ad_storage / ad_user_data / ad_personalization as
+     *     GRANTED (gcs=G111) because GA is filed under "marketing"
+     *   - OpenTelemetry traces were posted to the collector despite the service
+     *     being explicitly refused
+     * The Usercentrics GTM template got the same case right (all ad signals
+     * denied), which is what identified the app as the source.
+     *
+     * Service ids are read from the CMP at runtime rather than hardcoded — they
+     * differ per Usercentrics account and must not be baked into the repo.
+     */
+    test('eclass.justdoad.ch: accepting only Google Analytics grants nothing else', async ({
+        browser,
+    }) => {
+        const context = await browser.newContext({
+            locale: 'de-CH',
+            timezoneId: 'Europe/Zurich',
+            userAgent: REAL_UA,
+        });
+        await applyHumanFingerprint(context);
+        const page = await context.newPage();
+
+        const otelRequests: string[] = [];
+        page.on('request', (request) => {
+            if (/\/v1\/(traces|metrics|logs)/.test(request.url())) {
+                otelRequests.push(request.url());
+            }
+        });
+
+        try {
+            await page.goto('https://eclass.justdoad.ch/', {
+                waitUntil: 'domcontentloaded',
+            });
+            await page.waitForTimeout(SETTLE_MS);
+
+            // Resolve the CMP's own ids for the services we care about.
+            const ids = await page.evaluate(async () => {
+                const cmp = (
+                    window as unknown as {
+                        __ucCmp?: { getConsentDetails?: () => Promise<unknown> };
+                    }
+                ).__ucCmp;
+                const details = (await cmp?.getConsentDetails?.()) as
+                    | { services?: Record<string, { name?: string }> }
+                    | undefined;
+                const find = (fragment: string) =>
+                    Object.entries(details?.services ?? {}).find(([, service]) =>
+                        (service.name ?? '').toLowerCase().includes(fragment),
+                    )?.[0];
+                return {
+                    ga: find('google analytics'),
+                    otel: find('opentelemetry'),
+                };
+            });
+            expect(ids.ga, 'Google Analytics service not found in CMP').toBeTruthy();
+            expect(ids.otel, 'OpenTelemetry service not found in CMP').toBeTruthy();
+
+            // Open the second layer, enable ONLY Google Analytics, save.
+            await page.evaluate(() =>
+                (
+                    window as unknown as {
+                        UC_UI?: { showSecondLayer?: () => void };
+                    }
+                ).UC_UI?.showSecondLayer?.(),
+            );
+            await page.waitForTimeout(3_000);
+            await page.evaluate((gaId) => {
+                const root = document.querySelector('#usercentrics-cmp-ui')
+                    ?.shadowRoot;
+                const toggle = root?.getElementById(`uc-service-${gaId}-toggle`);
+                if (toggle?.getAttribute('aria-checked') !== 'true') {
+                    (toggle as HTMLElement | null)?.click();
+                }
+            }, ids.ga);
+            await page.waitForTimeout(800);
+
+            const dataLayerMark = await page.evaluate(
+                () =>
+                    ((window as unknown as { dataLayer?: unknown[] }).dataLayer ?? [])
+                        .length,
+            );
+            const otelMark = otelRequests.length;
+
+            await page.locator('#usercentrics-cmp-ui button[data-action-type="save"]').click();
+            await page.waitForTimeout(9_000);
+
+            const result = await page.evaluate(async (mark) => {
+                const cmp = (
+                    window as unknown as {
+                        __ucCmp?: { getConsentDetails?: () => Promise<unknown> };
+                    }
+                ).__ucCmp;
+                const details = (await cmp?.getConsentDetails?.()) as
+                    | {
+                          services?: Record<
+                              string,
+                              { name?: string; consent?: { given?: boolean } }
+                          >;
+                      }
+                    | undefined;
+                const given = (fragment: string) =>
+                    Object.values(details?.services ?? {}).some(
+                        (service) =>
+                            (service.name ?? '').toLowerCase().includes(fragment) &&
+                            !!service.consent?.given,
+                    );
+
+                const layer =
+                    (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? [];
+                const updates: Record<string, string>[] = [];
+                for (const entry of layer.slice(mark)) {
+                    const args = Array.from((entry ?? []) as ArrayLike<unknown>);
+                    if (args[0] === 'consent' && args[1] === 'update') {
+                        updates.push(args[2] as Record<string, string>);
+                    }
+                }
+                return {
+                    gaGiven: given('google analytics'),
+                    otelGiven: given('opentelemetry'),
+                    updates,
+                };
+            }, dataLayerMark);
+
+            console.log('\n──────── granular save: only Google Analytics accepted ────────');
+            console.log(`Google Analytics consented : ${result.gaGiven}`);
+            console.log(`OpenTelemetry consented    : ${result.otelGiven}`);
+            for (const update of result.updates) {
+                console.log(`   consent update → ${JSON.stringify(update)}`);
+            }
+            console.log(
+                `OTel collector posts after save: ${otelRequests.length - otelMark}`,
+            );
+
+            // Precondition: the click actually took effect.
+            expect(result.gaGiven, 'Google Analytics should be consented').toBe(true);
+            expect(result.otelGiven, 'OpenTelemetry should NOT be consented').toBe(false);
+
+            // Accepting an analytics service must not grant advertising.
+            const adGrants = result.updates.filter(
+                (update) =>
+                    update.ad_storage === 'granted' ||
+                    update.ad_user_data === 'granted' ||
+                    update.ad_personalization === 'granted',
+            );
+            expect(
+                adGrants,
+                'Advertising consent was granted although only Google Analytics was accepted',
+            ).toEqual([]);
+
+            // ...and must not start telemetry for a service that was refused.
+            expect(
+                otelRequests.length - otelMark,
+                'OpenTelemetry traces were sent although the service was refused',
+            ).toBe(0);
+        } finally {
+            await context.close();
+        }
+    });
+
     test('both sites share one Usercentrics configuration', async ({ browser }) => {
         // Documents WHY one dashboard change fixes both sites — and why neither
         // can be fixed in isolation.

--- a/apps/platform-e2e/src/consent-audit.spec.ts
+++ b/apps/platform-e2e/src/consent-audit.spec.ts
@@ -1,0 +1,620 @@
+import { test, expect, type Page, type BrowserContext } from '@playwright/test';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * LIVE CONSENT AUDIT — "premature consent grant" (Google Consent Mode).
+ *
+ * WHAT THIS PROVES
+ * ----------------
+ * A first-time visitor who has NOT touched the cookie banner must not have any
+ * tracking consent granted. Concretely, before any interaction:
+ *   - no non-essential service may report consent `given: true`
+ *   - no `gtag('consent','update', ... 'granted')` may reach the dataLayer
+ *   - every GA4 hit must carry `gcs=G100` (ad_storage + analytics_storage denied)
+ *
+ * These tests FAIL while the bug is present and PASS once it is fixed, so the
+ * same suite serves as both the bug report and the acceptance check.
+ *
+ * SCOPE — BOTH PRODUCTION SITES
+ * -----------------------------
+ * justdoad.ai (Wix) and eclass.justdoad.ch (Next.js) share ONE Usercentrics
+ * configuration (settings id `jnaPMX-WDaJ4Ig`), so both are affected and one
+ * dashboard fix repairs both. Measured pre-click on 2026-07-18:
+ *   justdoad.ai         G100 -> G101   (analytics granted, no click)
+ *   eclass.justdoad.ch  G100 -> G111   (analytics + ads granted, no click)
+ * The shared `G101` is the Usercentrics GTM template acting on implicit
+ * consent; the extra `G111` on eclass is the app's own consent bridge
+ * escalating it. This disproves the assumption that the Wix site was clean and
+ * that the defect was specific to the Next.js integration.
+ *
+ * WHY THE BOT-EVASION BELOW IS LOAD-BEARING
+ * -----------------------------------------
+ * Usercentrics detects headless automation (it appends `isBot=true` to its
+ * config request) and serves a PERMISSIVE configuration to bots: consent is
+ * reported as not required and everything as accepted. A naive Playwright run
+ * therefore measures the bot config, not what a real visitor gets — it can
+ * report a false "all clear" on a genuinely broken site, or a false alarm on a
+ * healthy one. `applyHumanFingerprint()` keeps the measurement honest; the
+ * suite asserts the bot config was NOT served.
+ */
+
+const SITES = [
+    { name: 'justdoad.ai (Wix)', url: 'https://www.justdoad.ai/' },
+    { name: 'eclass.justdoad.ch (Next.js)', url: 'https://eclass.justdoad.ch/' },
+] as const;
+
+/** Time allowed for the CMP + GTM + GA4 to load and settle. */
+const SETTLE_MS = 13_000;
+
+const REAL_UA =
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
+interface TUcService {
+    name: string;
+    category: string;
+    essential: boolean;
+    given: boolean;
+    /** 'EXPLICIT' = the user chose it; 'IMPLICIT' = pre-interaction default. */
+    type: string | undefined;
+}
+
+interface TConsentUpdate {
+    [signal: string]: string;
+}
+
+interface TGaHit {
+    gcs: string | null;
+    event: string | null;
+}
+
+interface TObservation {
+    isBotConfig: boolean;
+    settingsId: string | undefined;
+    consentRequired: boolean | undefined;
+    overallStatus: string | undefined;
+    services: TUcService[];
+    updates: TConsentUpdate[];
+    gaHits: TGaHit[];
+}
+
+/**
+ * Make the automated browser look like an ordinary one so Usercentrics serves
+ * the real visitor configuration. See the file header.
+ */
+async function applyHumanFingerprint(context: BrowserContext): Promise<void> {
+    await context.addInitScript(() => {
+        Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    });
+}
+
+/** `gcs=G1<ad_storage><analytics_storage>`, 1 = granted, 0 = denied. */
+function describeGcs(gcs: string | null): string {
+    switch (gcs) {
+        case 'G100':
+            return 'G100 (both denied — correct before consent)';
+        case 'G101':
+            return 'G101 (analytics_storage GRANTED)';
+        case 'G110':
+            return 'G110 (ad_storage GRANTED)';
+        case 'G111':
+            return 'G111 (analytics + ad storage GRANTED)';
+        default:
+            return `${gcs ?? 'none'} (unrecognised)`;
+    }
+}
+
+function isGrantedUpdate(update: TConsentUpdate): boolean {
+    return Object.values(update).includes('granted');
+}
+
+/**
+ * Load the site as a brand-new visitor and record the consent state WITHOUT
+ * touching the banner.
+ */
+async function observeSite(page: Page, url: string): Promise<TObservation> {
+    const gaHits: TGaHit[] = [];
+    let isBotConfig = false;
+
+    page.on('request', (request) => {
+        const requestUrl = request.url();
+        if (!requestUrl.includes('/g/collect')) return;
+        try {
+            const params = new URL(requestUrl).searchParams;
+            gaHits.push({ gcs: params.get('gcs'), event: params.get('en') });
+        } catch {
+            /* non-parsable URL — ignore */
+        }
+    });
+
+    page.on('response', (response) => {
+        // Usercentrics flags automated browsers on its config request.
+        if (/api\.service\.cmp\.usercentrics/.test(response.url()) &&
+            response.url().includes('isBot=true')) {
+            isBotConfig = true;
+        }
+    });
+
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    // The banner is deliberately NOT interacted with.
+    await page.waitForTimeout(SETTLE_MS);
+
+    const state = await page.evaluate(async () => {
+        const cmp = (
+            window as unknown as {
+                __ucCmp?: { getConsentDetails?: () => Promise<unknown> };
+            }
+        ).__ucCmp;
+        const details = (await cmp?.getConsentDetails?.()) as
+            | {
+                  consent?: {
+                      required?: boolean;
+                      status?: string;
+                      setting?: { id?: string };
+                  };
+                  services?: Record<
+                      string,
+                      {
+                          name?: string;
+                          category?: string;
+                          essential?: boolean;
+                          consent?: { given?: boolean; type?: string };
+                      }
+                  >;
+              }
+            | undefined;
+
+        const services = Object.values(details?.services ?? {}).map((service) => ({
+            name: service.name ?? '(unnamed)',
+            category: service.category ?? '(none)',
+            essential: !!service.essential,
+            given: !!service.consent?.given,
+            type: service.consent?.type,
+        }));
+
+        const layer =
+            (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? [];
+        const updates: Record<string, string>[] = [];
+        for (const entry of layer) {
+            const args = Array.from((entry ?? []) as ArrayLike<unknown>);
+            if (args[0] === 'consent' && args[1] === 'update') {
+                updates.push(args[2] as Record<string, string>);
+            }
+        }
+
+        return {
+            settingsId: details?.consent?.setting?.id,
+            consentRequired: details?.consent?.required,
+            overallStatus: details?.consent?.status,
+            services,
+            updates,
+        };
+    });
+
+    return { ...state, isBotConfig, gaHits };
+}
+
+/** Human-readable evidence block — this is what gets shared with the client. */
+function report(siteName: string, observed: TObservation): void {
+    const implicitlyGranted = observed.services.filter(
+        (service) => !service.essential && service.given,
+    );
+    const grantedUpdates = observed.updates.filter(isGrantedUpdate);
+    const leakyHits = observed.gaHits.filter(
+        (hit) => hit.gcs !== null && hit.gcs !== 'G100',
+    );
+
+    console.log(`\n──────── ${siteName} ────────`);
+    console.log(`Usercentrics settings id : ${observed.settingsId ?? 'unknown'}`);
+    console.log(`consent required         : ${observed.consentRequired}`);
+    console.log(`overall consent status   : ${observed.overallStatus}`);
+    console.log(
+        `\nNon-essential services granted BEFORE any click (${implicitlyGranted.length}):`,
+    );
+    for (const service of implicitlyGranted) {
+        console.log(
+            `   ✗ ${service.name}  [${service.category}]  type=${service.type}`,
+        );
+    }
+    console.log(`\nGA4 hits and their Consent Mode signal:`);
+    for (const hit of observed.gaHits) {
+        const marker = hit.gcs === 'G100' ? '✓' : '✗';
+        console.log(`   ${marker} ${hit.event ?? '(no event)'} → ${describeGcs(hit.gcs)}`);
+    }
+    console.log(
+        `\nGranted consent updates pushed pre-click: ${grantedUpdates.length}`,
+    );
+    for (const update of grantedUpdates) {
+        console.log(`   ✗ ${JSON.stringify(update)}`);
+    }
+    console.log(
+        `\nSUMMARY: ${implicitlyGranted.length} implicit grants, ` +
+            `${grantedUpdates.length} granted updates, ` +
+            `${leakyHits.length} GA4 hits above G100\n`,
+    );
+}
+
+/**
+ * Every run is saved to `apps/platform-e2e/consent-audit-results/` so the
+ * before/after evidence is durable and diffable.
+ *
+ *   AUDIT_LABEL=before-fix  pnpm exec playwright test -c .../consent-audit.config.ts
+ *   AUDIT_LABEL=after-fix   pnpm exec playwright test -c .../consent-audit.config.ts
+ */
+const AUDIT_LABEL = process.env.AUDIT_LABEL || 'unlabelled';
+// Playwright transpiles specs to CJS, so __dirname is the reliable anchor here
+// (import.meta is unavailable) — keeps output next to the suite regardless of
+// which directory the run was launched from.
+const RESULTS_DIR = join(__dirname, '..', 'consent-audit-results');
+
+const collected: { site: string; url: string; observed: TObservation }[] = [];
+
+function verdictFor(observed: TObservation) {
+    const implicitlyGranted = observed.services.filter(
+        (service) => !service.essential && service.given,
+    );
+    const grantedUpdates = observed.updates.filter(isGrantedUpdate);
+    const leakyHits = observed.gaHits.filter(
+        (hit) => hit.gcs !== null && hit.gcs !== 'G100',
+    );
+    return {
+        implicitlyGranted,
+        grantedUpdates,
+        leakyHits,
+        pass:
+            implicitlyGranted.length === 0 &&
+            grantedUpdates.length === 0 &&
+            leakyHits.length === 0,
+    };
+}
+
+function writeArtifacts(): void {
+    if (collected.length === 0) return;
+    mkdirSync(RESULTS_DIR, { recursive: true });
+    const takenAt = new Date().toISOString();
+    const jsonPath = join(RESULTS_DIR, `consent-audit-${AUDIT_LABEL}.json`);
+
+    // Playwright restarts its worker process after a test failure, which clears
+    // this module's in-memory state — so each surviving site would otherwise
+    // overwrite the previous one. Merge with whatever is already on disk for
+    // this label, keyed by site, keeping the newest observation per site.
+    const merged = new Map<string, (typeof collected)[number]>();
+    try {
+        const prior = JSON.parse(readFileSync(jsonPath, 'utf8')) as {
+            label?: string;
+            sites?: typeof collected;
+        };
+        // Only reuse entries from the same run label.
+        if (prior.label === AUDIT_LABEL) {
+            for (const entry of prior.sites ?? []) merged.set(entry.site, entry);
+        }
+    } catch {
+        // No previous file for this label — first site of the run.
+    }
+    for (const entry of collected) merged.set(entry.site, entry);
+
+    const sites = SITES.map((s) => merged.get(s.name)).filter(
+        (entry): entry is (typeof collected)[number] => !!entry,
+    );
+
+    writeFileSync(
+        jsonPath,
+        JSON.stringify({ label: AUDIT_LABEL, takenAt, sites }, null, 2) + '\n',
+    );
+
+    const lines: string[] = [
+        `# Consent Mode audit — \`${AUDIT_LABEL}\``,
+        '',
+        `Taken: ${takenAt}`,
+        '',
+        'A first-time visitor who has NOT touched the cookie banner must have no',
+        'tracking consent: no non-essential service granted, no granted `gtag`',
+        'consent update, and every GA4 hit at `gcs=G100`.',
+        '',
+    ];
+
+    for (const { site, url, observed } of sites) {
+        const v = verdictFor(observed);
+        lines.push(
+            `## ${site}`,
+            '',
+            `- URL: ${url}`,
+            `- Usercentrics settings id: \`${observed.settingsId ?? 'unknown'}\``,
+            `- consent required: \`${observed.consentRequired}\``,
+            `- overall status: \`${observed.overallStatus}\``,
+            `- **verdict: ${v.pass ? 'PASS ✅' : 'FAIL ❌'}**`,
+            '',
+            `### Non-essential services granted before any click (${v.implicitlyGranted.length})`,
+            '',
+        );
+        if (v.implicitlyGranted.length === 0) {
+            lines.push('_None — correct._', '');
+        } else {
+            lines.push('| Service | Category | Consent type |', '| --- | --- | --- |');
+            for (const s of v.implicitlyGranted) {
+                lines.push(`| ${s.name} | ${s.category} | ${s.type} |`);
+            }
+            lines.push('');
+        }
+
+        lines.push('### GA4 hits', '', '| Event | Consent Mode signal |', '| --- | --- |');
+        for (const hit of observed.gaHits) {
+            lines.push(
+                `| ${hit.event ?? '(no event)'} | ${hit.gcs === 'G100' ? '✅' : '❌'} ${describeGcs(hit.gcs)} |`,
+            );
+        }
+        lines.push('');
+
+        lines.push(
+            `### Granted consent updates pushed pre-click (${v.grantedUpdates.length})`,
+            '',
+        );
+        if (v.grantedUpdates.length === 0) {
+            lines.push('_None — correct._', '');
+        } else {
+            for (const u of v.grantedUpdates) {
+                lines.push('- `' + JSON.stringify(u) + '`');
+            }
+            lines.push('');
+        }
+    }
+
+    const ids = [...new Set(sites.map((c) => c.observed.settingsId))];
+    lines.push(
+        '## Shared configuration',
+        '',
+        ids.length === 1
+            ? `Both sites load the same Usercentrics configuration \`${ids[0]}\`, so one dashboard change affects both.`
+            : `Sites load different configurations: ${ids.join(', ')}.`,
+        '',
+    );
+
+    writeFileSync(join(RESULTS_DIR, `consent-audit-${AUDIT_LABEL}.md`), lines.join('\n'));
+    console.log(`\nSaved audit artifacts to ${RESULTS_DIR} (label: ${AUDIT_LABEL})`);
+}
+
+test.afterAll(() => {
+    writeArtifacts();
+});
+
+test.describe('Consent Mode audit — no tracking consent before the user clicks', () => {
+    for (const site of SITES) {
+        test(`${site.name}: nothing is granted before the banner is touched`, async ({
+            browser,
+        }) => {
+            // Fresh context = first-time visitor: no cookies, no stored consent.
+            const context = await browser.newContext({
+                locale: 'de-CH',
+                timezoneId: 'Europe/Zurich',
+                userAgent: REAL_UA,
+            });
+            await applyHumanFingerprint(context);
+            const page = await context.newPage();
+
+            try {
+                const observed = await observeSite(page, site.url);
+                report(site.name, observed);
+                // Record BEFORE asserting so a failing run still writes evidence.
+                collected.push({ site: site.name, url: site.url, observed });
+
+                // Guard: if Usercentrics served its permissive bot config, the
+                // measurement is meaningless — fail loudly rather than pass.
+                expect(
+                    observed.isBotConfig,
+                    'Usercentrics served its bot configuration; the run does not ' +
+                        'reflect a real visitor. Bot evasion needs updating.',
+                ).toBe(false);
+
+                expect(
+                    observed.services.length,
+                    'No Usercentrics services were read — the CMP did not load, ' +
+                        'so nothing was actually verified.',
+                ).toBeGreaterThan(0);
+
+                // (1) No non-essential service may be granted pre-interaction.
+                const implicitlyGranted = observed.services
+                    .filter((service) => !service.essential && service.given)
+                    .map((service) => `${service.name} [${service.category}]`);
+                expect(
+                    implicitlyGranted,
+                    'These non-essential services report consent BEFORE the user ' +
+                        'chose anything (Usercentrics Service Settings pre-grants them)',
+                ).toEqual([]);
+
+                // (2) No granted consent update may reach the dataLayer.
+                const grantedUpdates = observed.updates.filter(isGrantedUpdate);
+                expect(
+                    grantedUpdates,
+                    'A granted gtag consent update was pushed before any interaction',
+                ).toEqual([]);
+
+                // (3) Every GA4 hit must be fully denied.
+                const leakyHits = observed.gaHits
+                    .filter((hit) => hit.gcs !== null && hit.gcs !== 'G100')
+                    .map((hit) => `${hit.event ?? '(no event)'}=${hit.gcs}`);
+                expect(
+                    leakyHits,
+                    'GA4 hits fired with consent granted before any interaction',
+                ).toEqual([]);
+            } finally {
+                await context.close();
+            }
+        });
+    }
+
+    /**
+     * REVERSE DIRECTION — consent must actually turn ON after an explicit Accept.
+     *
+     * The tests above only prove nothing is granted BEFORE interaction. That
+     * half can be satisfied by a CMP that never grants anything at all, which
+     * would look "fixed" while silently recording no analytics. This test
+     * closes that gap: after a real click on the banner's Accept button,
+     * consent must flip to EXPLICIT and GA4 must report granted storage.
+     *
+     * The click happens in a throwaway, isolated browser context (fresh
+     * profile, discarded at the end). No real user's consent is recorded.
+     *
+     * Selector note: the Usercentrics v3 banner renders inside the OPEN shadow
+     * root of `#usercentrics-cmp-ui`; Playwright pierces open shadow roots with
+     * CSS. `[data-action-type="accept"]` is used rather than button text so the
+     * test does not break when the banner language changes.
+     */
+    for (const site of SITES) {
+        test(`${site.name}: consent IS granted after an explicit Accept`, async ({
+            browser,
+        }) => {
+            const context = await browser.newContext({
+                locale: 'de-CH',
+                timezoneId: 'Europe/Zurich',
+                userAgent: REAL_UA,
+            });
+            await applyHumanFingerprint(context);
+            const page = await context.newPage();
+
+            const gaHits: TGaHit[] = [];
+            page.on('request', (request) => {
+                const requestUrl = request.url();
+                if (!requestUrl.includes('/g/collect')) return;
+                try {
+                    const params = new URL(requestUrl).searchParams;
+                    gaHits.push({
+                        gcs: params.get('gcs'),
+                        event: params.get('en'),
+                    });
+                } catch {
+                    /* ignore */
+                }
+            });
+
+            try {
+                await page.goto(site.url, { waitUntil: 'domcontentloaded' });
+                await page.waitForTimeout(SETTLE_MS);
+
+                const acceptButton = page.locator(
+                    '#usercentrics-cmp-ui button[data-action-type="accept"]',
+                );
+                await expect(
+                    acceptButton,
+                    'The Usercentrics Accept button was not found — the banner did ' +
+                        'not render, so consent could not be granted.',
+                ).toBeVisible();
+
+                const hitsBeforeClick = gaHits.length;
+                await acceptButton.click();
+                // Let the CMP persist the decision and GTM re-fire tags.
+                await page.waitForTimeout(8_000);
+
+                const after = await page.evaluate(async () => {
+                    const cmp = (
+                        window as unknown as {
+                            __ucCmp?: {
+                                getConsentDetails?: () => Promise<unknown>;
+                            };
+                        }
+                    ).__ucCmp;
+                    const details = (await cmp?.getConsentDetails?.()) as
+                        | {
+                              consent?: { status?: string };
+                              services?: Record<
+                                  string,
+                                  {
+                                      name?: string;
+                                      essential?: boolean;
+                                      consent?: {
+                                          given?: boolean;
+                                          type?: string;
+                                      };
+                                  }
+                              >;
+                          }
+                        | undefined;
+                    const services = Object.values(details?.services ?? {});
+                    const ga = services.find((s) =>
+                        (s.name ?? '').toLowerCase().startsWith('google analytics'),
+                    );
+                    return {
+                        status: details?.consent?.status,
+                        gaGiven: !!ga?.consent?.given,
+                        gaType: ga?.consent?.type,
+                        explicitCount: services.filter(
+                            (s) => s.consent?.type === 'EXPLICIT',
+                        ).length,
+                    };
+                });
+
+                const postClickHits = gaHits.slice(hitsBeforeClick);
+                const grantedHits = postClickHits.filter(
+                    (hit) => hit.gcs !== null && hit.gcs !== 'G100',
+                );
+
+                console.log(`\n──────── ${site.name} — after explicit Accept ────────`);
+                console.log(`overall status        : ${after.status}`);
+                console.log(
+                    `Google Analytics      : given=${after.gaGiven} type=${after.gaType}`,
+                );
+                console.log(`services now EXPLICIT : ${after.explicitCount}`);
+                console.log(`GA4 hits after click  :`);
+                for (const hit of postClickHits) {
+                    console.log(
+                        `   ${hit.gcs === 'G100' ? '✗' : '✓'} ${hit.event ?? '(no event)'} → ${describeGcs(hit.gcs)}`,
+                    );
+                }
+
+                // Consent must now be recorded as a real user decision.
+                expect(
+                    after.gaType,
+                    'After clicking Accept, Google Analytics consent should be ' +
+                        'recorded as EXPLICIT (a genuine user decision)',
+                ).toBe('EXPLICIT');
+                expect(
+                    after.gaGiven,
+                    'After clicking Accept, Google Analytics should be consented',
+                ).toBe(true);
+
+                // ...and analytics must actually be switched on downstream.
+                expect(
+                    grantedHits.length,
+                    'After an explicit Accept, GA4 should fire with consent ' +
+                        'granted (gcs above G100). Staying at G100 would mean ' +
+                        'analytics is silently dead for consenting users.',
+                ).toBeGreaterThan(0);
+            } finally {
+                await context.close();
+            }
+        });
+    }
+
+    test('both sites share one Usercentrics configuration', async ({ browser }) => {
+        // Documents WHY one dashboard change fixes both sites — and why neither
+        // can be fixed in isolation.
+        const seen: Record<string, string | undefined> = {};
+
+        for (const site of SITES) {
+            const context = await browser.newContext({
+                locale: 'de-CH',
+                timezoneId: 'Europe/Zurich',
+                userAgent: REAL_UA,
+            });
+            await applyHumanFingerprint(context);
+            const page = await context.newPage();
+            try {
+                const observed = await observeSite(page, site.url);
+                seen[site.name] = observed.settingsId;
+            } finally {
+                await context.close();
+            }
+        }
+
+        console.log('\nUsercentrics settings id per site:');
+        for (const [name, id] of Object.entries(seen)) {
+            console.log(`   ${name}: ${id}`);
+        }
+
+        const ids = Object.values(seen);
+        expect(ids.every((id) => !!id)).toBe(true);
+        expect(
+            new Set(ids).size,
+            'Both sites are expected to share one Usercentrics configuration',
+        ).toBe(1);
+    });
+});

--- a/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
@@ -111,10 +111,29 @@ interface TNormalizedService {
 function mapServicesToConsentState(
     services: TNormalizedService[],
 ): TConsentState {
+    const isGoogleAnalytics = (s: TNormalizedService): boolean =>
+        typeof s.name === 'string' &&
+        s.name.toLowerCase().startsWith('google analytics');
+
+    // Google Analytics is deliberately excluded from category aggregation and
+    // handled only by hasGoogleAnalyticsConsent below.
+    //
+    // Measured on production: a user who opened the CMP's granular settings and
+    // accepted ONLY Google Analytics had ad_storage, ad_user_data and
+    // ad_personalization granted (gcs=G111). GA is filed under "marketing" in
+    // this tenant's dashboard, so it alone flipped the marketing category and,
+    // through it, every advertising signal — for a user who consented to an
+    // analytics service and nothing else. The Usercentrics GTM template got the
+    // same case right (it pushed all ad signals denied); only our mapping
+    // disagreed, which is what identified this as ours.
+    //
+    // GA is an analytics service whichever category the dashboard files it
+    // under, so its consent must not imply advertising consent.
     const has = (categories: string[]): boolean =>
         services.some(
             (s) =>
                 s.granted &&
+                !isGoogleAnalytics(s) &&
                 typeof s.category === 'string' &&
                 categories.includes(s.category.toLowerCase()),
         );
@@ -132,10 +151,7 @@ function mapServicesToConsentState(
     // apps/platform-e2e/src/consent-audit.spec.ts — which would catch the
     // regression against production; run it after any CMP dashboard change.
     const hasGoogleAnalyticsConsent = services.some(
-        (s) =>
-            s.granted &&
-            typeof s.name === 'string' &&
-            s.name.toLowerCase().startsWith('google analytics'),
+        (s) => s.granted && isGoogleAnalytics(s),
     );
 
     // Per-service consent, so callers can gate ONE integration precisely

--- a/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
@@ -123,6 +123,14 @@ function mapServicesToConsentState(
     // statistics/analytics category at all and file Google Analytics under
     // "marketing". The user's per-service consent to GA itself IS analytics
     // consent, regardless of which category the dashboard admin chose.
+    //
+    // This matches on a dashboard-editable label, so it is brittle by nature:
+    // renaming the service in Usercentrics silently reopens the gcs=G110 bug
+    // with no compile-time or unit-test signal. A per-tenant service id is not
+    // a safe substitute (ids differ per account, and env-specific values must
+    // not be hardcoded here). The tripwire is the live audit —
+    // apps/platform-e2e/src/consent-audit.spec.ts — which would catch the
+    // regression against production; run it after any CMP dashboard change.
     const hasGoogleAnalyticsConsent = services.some(
         (s) =>
             s.granted &&

--- a/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/consent/usercentrics-adapter.ts
@@ -2,6 +2,19 @@ import { DENIED_CONSENT, type TConsentState } from '../types';
 import type { TConsentAdapter } from './consent-adapter';
 
 /**
+ * Usercentrics records HOW a service's consent was set, not just whether it is
+ * currently granted:
+ *   - 'EXPLICIT' — the user actively made this choice (Accept / Deny / Save).
+ *   - 'IMPLICIT' — a default/pre-interaction state (e.g. "consent by default"
+ *     in opt-out regions, or the baseline the CMP reports on first load before
+ *     the banner is touched).
+ * See Usercentrics' CONSENT_TYPE enum. `status` alone is NOT sufficient: on a
+ * first visit the CMP can report `status: true, type: 'IMPLICIT'`, and acting
+ * on that would grant tracking before the user consented.
+ */
+type TConsentType = 'EXPLICIT' | 'IMPLICIT';
+
+/**
  * Minimal shape of window.UC_UI we rely on.
  *
  * Usercentrics CMP v3 exposes a larger API — we only use what the adapter
@@ -12,7 +25,7 @@ interface TUserCentricsService {
     id?: string;
     name?: string;
     categorySlug?: string;
-    consent?: { status?: boolean };
+    consent?: { status?: boolean; type?: TConsentType };
 }
 
 interface TUserCentricsUI {
@@ -22,7 +35,12 @@ interface TUserCentricsUI {
     /**
      * CMP v3 versions up to ~3.120 return the array synchronously; newer
      * versions (observed live on v3.121.2) return a Promise. The adapter
-     * must support both — see emitConsentState below.
+     * must support both — see readServices below.
+     *
+     * NOTE: verified live (2026-08) that this payload is `{status, history}`
+     * only — it carries NO `consent.type`, so it cannot distinguish an
+     * explicit user decision from an implicit default. `__ucCmp` below is the
+     * preferred source for exactly that reason.
      */
     getServicesBaseInfo?: () =>
         | TUserCentricsService[]
@@ -31,10 +49,46 @@ interface TUserCentricsUI {
     hidePrivacyButton?: () => void;
 }
 
+/**
+ * Newer hosted CMP builds expose `window.__ucCmp`, whose `getConsentDetails()`
+ * DOES report per-service `{given, type}` — the only place the
+ * EXPLICIT/IMPLICIT distinction is actually available to us.
+ *
+ * Note the shape differs from getServicesBaseInfo(): services come back as a
+ * keyed object (not an array), the category field is `category` (not
+ * `categorySlug`), and consent is `given` (not `status`).
+ */
+interface TUcCmpService {
+    name?: string;
+    category?: string;
+    essential?: boolean;
+    consent?: { given?: boolean; type?: TConsentType };
+}
+
+interface TUcCmpConsentDetails {
+    consent?: { status?: string; required?: boolean };
+    services?: Record<string, TUcCmpService>;
+}
+
+interface TUcCmp {
+    getConsentDetails?: () => Promise<TUcCmpConsentDetails>;
+}
+
 declare global {
     interface Window {
         UC_UI?: TUserCentricsUI;
+        __ucCmp?: TUcCmp;
     }
+}
+
+/**
+ * Source-agnostic view of one CMP service, with `granted` already resolved
+ * according to what the source can actually tell us about explicitness.
+ */
+interface TNormalizedService {
+    name?: string;
+    category?: string;
+    granted: boolean;
 }
 
 /**
@@ -55,14 +109,14 @@ declare global {
  * default.
  */
 function mapServicesToConsentState(
-    services: TUserCentricsService[],
+    services: TNormalizedService[],
 ): TConsentState {
     const has = (categories: string[]): boolean =>
         services.some(
             (s) =>
-                !!s.consent?.status &&
-                typeof s.categorySlug === 'string' &&
-                categories.includes(s.categorySlug.toLowerCase()),
+                s.granted &&
+                typeof s.category === 'string' &&
+                categories.includes(s.category.toLowerCase()),
         );
 
     // Tenant dashboards (e.g. eclass.justdoad.ch) may have no
@@ -71,21 +125,96 @@ function mapServicesToConsentState(
     // consent, regardless of which category the dashboard admin chose.
     const hasGoogleAnalyticsConsent = services.some(
         (s) =>
-            !!s.consent?.status &&
+            s.granted &&
             typeof s.name === 'string' &&
             s.name.toLowerCase().startsWith('google analytics'),
     );
+
+    // Per-service consent, so callers can gate ONE integration precisely
+    // instead of relying on a category proxy. See hasServiceConsent().
+    const perService: Record<string, boolean> = {};
+    for (const service of services) {
+        if (typeof service.name !== 'string') continue;
+        const key = service.name.toLowerCase();
+        // A name could appear twice; consent to either counts.
+        perService[key] = perService[key] || service.granted;
+    }
 
     return {
         analytics:
             has(['statistics', 'analytics']) || hasGoogleAnalyticsConsent,
         marketing: has(['marketing']),
         preferences: has(['functional', 'preferences']),
+        services: perService,
     };
 }
 
-function isThenable(value: unknown): value is Promise<TUserCentricsService[]> {
+/**
+ * PREFERRED source. `__ucCmp.getConsentDetails()` reports `consent.type`, so we
+ * can require an EXPLICIT (user-made) decision and ignore IMPLICIT
+ * pre-interaction defaults.
+ *
+ * This is the defence-in-depth guard: if the CMP dashboard is ever
+ * misconfigured to pre-grant services (services reporting `given: true` with
+ * `type: 'IMPLICIT'` before the banner is touched), the app refuses to turn
+ * that into a gtag consent grant or to start first-party telemetry.
+ */
+function normalizeFromCmpDetails(
+    details: TUcCmpConsentDetails,
+): TNormalizedService[] {
+    return Object.values(details.services ?? {}).map((service) => ({
+        name: service.name,
+        category: service.category,
+        granted:
+            !!service.consent?.given && service.consent?.type === 'EXPLICIT',
+    }));
+}
+
+/**
+ * FALLBACK source, used only when `__ucCmp` is unavailable.
+ *
+ * Verified live: this payload has no `consent.type`, so explicitness cannot be
+ * determined here. We deliberately fail OPEN and trust `status` — matching the
+ * long-standing behaviour — rather than fail closed.
+ *
+ * Rationale: the CMP configuration is the primary control for what may be
+ * granted; this adapter is a second layer. Failing closed on a source that
+ * simply cannot answer the question would permanently deny consent even for
+ * users who explicitly accepted, silently killing analytics (the gcs=G100
+ * incident). A missing `__ucCmp` is reported via warnMissingCmpApi() so the
+ * degraded path is observable rather than silent.
+ */
+function normalizeFromBaseInfo(
+    services: TUserCentricsService[],
+): TNormalizedService[] {
+    return services.map((service) => ({
+        name: service.name,
+        category: service.categorySlug,
+        granted: !!service.consent?.status,
+    }));
+}
+
+function isThenable<T>(value: unknown): value is Promise<T> {
     return !!value && typeof (value as { then?: unknown }).then === 'function';
+}
+
+/**
+ * Warn once per adapter instance: the explicit-consent guard is unavailable on
+ * this CMP build. Instance-scoped rather than module-scoped so the degraded
+ * path stays observable per adapter (and deterministically testable).
+ */
+function createMissingCmpApiWarner(): () => void {
+    let warned = false;
+    return () => {
+        if (warned) return;
+        warned = true;
+        console.warn(
+            '[consent] window.__ucCmp.getConsentDetails() unavailable — cannot ' +
+                'distinguish EXPLICIT from IMPLICIT consent. Falling back to ' +
+                'getServicesBaseInfo(); premature-grant protection is degraded ' +
+                'and the CMP configuration is the only safeguard.',
+        );
+    };
 }
 
 /**
@@ -102,6 +231,8 @@ function isThenable(value: unknown): value is Promise<TUserCentricsService[]> {
  * CMP event; the banner is opened via `window.UC_UI.showFirstLayer()`.
  */
 export function createUsercentricsAdapter(): TConsentAdapter {
+    const warnMissingCmpApi = createMissingCmpApiWarner();
+
     return {
         init() {
             // Hide the persistent floating privacy button ("fingerprint" icon)
@@ -156,6 +287,50 @@ export function createUsercentricsAdapter(): TConsentAdapter {
                     return;
                 }
 
+                /** Emit only if this read is still the newest and live. */
+                const emitIfCurrent = (services: TNormalizedService[]) => {
+                    if (!active || ticket !== seq) return;
+                    if (services.length === 0) return;
+                    handler(mapServicesToConsentState(services));
+                };
+
+                // PREFERRED: __ucCmp.getConsentDetails() — the only source that
+                // reports consent.type, so it can reject IMPLICIT pre-grants.
+                const cmp =
+                    typeof window !== 'undefined' ? window.__ucCmp : undefined;
+                if (typeof cmp?.getConsentDetails === 'function') {
+                    let details: unknown;
+                    try {
+                        details = cmp.getConsentDetails();
+                    } catch {
+                        emitDeniedFallback();
+                        return;
+                    }
+                    if (isThenable<TUcCmpConsentDetails>(details)) {
+                        emitDeniedFallback();
+                        details
+                            .then((resolved) => {
+                                emitIfCurrent(normalizeFromCmpDetails(resolved));
+                            })
+                            .catch(() => {
+                                // Keep the last emitted state on CMP errors.
+                            });
+                        return;
+                    }
+                    // Unexpected sync return — normalize what we got.
+                    emitIfCurrent(
+                        normalizeFromCmpDetails(
+                            (details ?? {}) as TUcCmpConsentDetails,
+                        ),
+                    );
+                    return;
+                }
+
+                // FALLBACK: getServicesBaseInfo(). Cannot see consent.type, so
+                // premature-grant protection is degraded here — see
+                // normalizeFromBaseInfo().
+                warnMissingCmpApi();
+
                 let services: unknown;
                 try {
                     services = ui.getServicesBaseInfo?.();
@@ -170,21 +345,23 @@ export function createUsercentricsAdapter(): TConsentAdapter {
                         emitDeniedFallback();
                         return;
                     }
-                    handler(mapServicesToConsentState(services));
+                    handler(
+                        mapServicesToConsentState(
+                            normalizeFromBaseInfo(services),
+                        ),
+                    );
                     return;
                 }
 
                 // CMP ≥ 3.121: Promise<service[]>. Resolve it and emit the
                 // REAL state; drop the result if a newer read started or the
                 // consumer unsubscribed in the meantime.
-                if (isThenable(services)) {
+                if (isThenable<TUserCentricsService[]>(services)) {
                     emitDeniedFallback();
                     services
                         .then((resolved) => {
-                            if (!active || ticket !== seq) return;
-                            if (Array.isArray(resolved) && resolved.length > 0) {
-                                handler(mapServicesToConsentState(resolved));
-                            }
+                            if (!Array.isArray(resolved)) return;
+                            emitIfCurrent(normalizeFromBaseInfo(resolved));
                         })
                         .catch(() => {
                             // Keep the last emitted state on CMP errors.

--- a/apps/platform/src/lib/infrastructure/client/analytics/types.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/types.ts
@@ -26,6 +26,22 @@ export interface TConsentState {
     marketing: boolean;
     /** Preference cookies (maps to `personalization_storage`). */
     preferences: boolean;
+    /**
+     * Per-service consent, keyed by lower-cased CMP service name.
+     *
+     * The three category flags above are a lossy summary: a category is true
+     * when ANY service in it is consented. That's fine for Google Consent Mode
+     * (which is category-shaped anyway), but wrong for gating one specific
+     * first-party integration — a user can consent to Google Analytics while
+     * refusing our OpenTelemetry monitoring, and the category flags conflate
+     * the two.
+     *
+     * Undefined when the CMP could not enumerate services (e.g. the noop
+     * adapter, or a failed read) — callers must treat "absent" as "no consent
+     * record", not as consent. Use hasServiceConsent() rather than reading
+     * this directly.
+     */
+    services?: Record<string, boolean>;
 }
 
 /** Default all-denied consent state used before the CMP has answered. */
@@ -34,3 +50,27 @@ export const DENIED_CONSENT: TConsentState = {
     marketing: false,
     preferences: false,
 };
+
+/**
+ * Look up consent for ONE specific CMP service by name fragment.
+ *
+ * Matching is a case-insensitive substring test against the service names the
+ * CMP reported, so a dashboard label like
+ * "Platform Performance & Error Monitoring (OpenTelemetry)" can be matched on a
+ * stable fragment ("opentelemetry") without pinning the full string.
+ *
+ * Returns `false` when the service is absent from the CMP payload: no consent
+ * record means no consent. This is deliberately stricter than falling back to a
+ * category flag — a category proxy is exactly what let monitoring run for users
+ * who had explicitly refused it.
+ */
+export function hasServiceConsent(
+    state: TConsentState,
+    nameFragment: string,
+): boolean {
+    if (!state.services) return false;
+    const needle = nameFragment.toLowerCase();
+    return Object.entries(state.services).some(
+        ([name, granted]) => granted && name.includes(needle),
+    );
+}

--- a/apps/platform/src/lib/infrastructure/client/analytics/types.ts
+++ b/apps/platform/src/lib/infrastructure/client/analytics/types.ts
@@ -63,6 +63,11 @@ export const DENIED_CONSENT: TConsentState = {
  * record means no consent. This is deliberately stricter than falling back to a
  * category flag — a category proxy is exactly what let monitoring run for users
  * who had explicitly refused it.
+ *
+ * Caveat: substring matching means an unrelated service whose name happens to
+ * contain the fragment would also match. Safe for the fragments in use today,
+ * but pick fragments specific enough to stay unambiguous as more per-service
+ * gates are added.
  */
 export function hasServiceConsent(
     state: TConsentState,

--- a/apps/platform/src/lib/infrastructure/client/telemetry/OTelBrowserProvider.tsx
+++ b/apps/platform/src/lib/infrastructure/client/telemetry/OTelBrowserProvider.tsx
@@ -2,6 +2,16 @@
 
 import { useEffect, ReactNode } from 'react';
 import { useConsent } from '../analytics/consent/consent-provider';
+import { hasServiceConsent } from '../analytics/types';
+
+/**
+ * Name fragment identifying this integration's own service in the CMP.
+ *
+ * Matches the Usercentrics service "Platform Performance & Error Monitoring
+ * (OpenTelemetry)". A fragment rather than the full label so a wording change
+ * in the dashboard doesn't silently break the gate.
+ */
+const OTEL_CMP_SERVICE = 'opentelemetry';
 
 /**
  * Configuration for the browser tracer.
@@ -60,13 +70,25 @@ export function OTelBrowserProvider({
     children,
     config,
 }: OTelBrowserProviderProps) {
-    // Gate on the analytics consent category — mirrors Usercentrics' classification
-    // of this DPS under Statistics / Analytics (Art. 6 para. 1 s. 1 lit. a GDPR).
-    // Browser performance telemetry + fetch traces read the Performance Observer
-    // API and transmit IP / URL / page.route off-device, which falls within
-    // ePrivacy Art. 5(3) and is not "strictly necessary" for service delivery.
+    // Gate on THIS integration's own CMP service, not on a consent category.
+    //
+    // Browser performance telemetry + fetch traces read the Performance
+    // Observer API and transmit IP / URL / page.route off-device, which falls
+    // within ePrivacy Art. 5(3) and is not "strictly necessary" for service
+    // delivery — so it needs the user's consent for this specific service.
+    //
+    // This previously gated on `consent.analytics`, on the assumption that the
+    // CMP filed this DPS under Statistics/Analytics. It does not: the service
+    // sits under "functional", and there is no statistics category at all on
+    // the account. The category proxy therefore misfired in both directions —
+    // most importantly it STARTED telemetry for users who had explicitly
+    // refused this service but accepted Google Analytics (which is filed under
+    // marketing and forces `analytics` true).
+    //
+    // If the CMP reports no record for the service, hasServiceConsent() returns
+    // false and telemetry stays off: absent consent is not consent.
     const { consent } = useConsent();
-    const hasConsent = consent.analytics;
+    const hasConsent = hasServiceConsent(consent, OTEL_CMP_SERVICE);
 
     useEffect(() => {
         if (!config || !config.enabled) return;

--- a/apps/platform/src/lib/infrastructure/client/telemetry/web-vitals.ts
+++ b/apps/platform/src/lib/infrastructure/client/telemetry/web-vitals.ts
@@ -82,11 +82,27 @@ function reportWebVital(metric: Metric): void {
  * captureWebVitals();
  * ```
  */
+/**
+ * The web-vitals library has no way to unregister a callback, so registering
+ * twice permanently doubles every reported metric. This is reachable through
+ * consent: a user who grants, revokes, then re-grants within one session (via
+ * the CMP's privacy settings) runs the OTelBrowserProvider effect again.
+ *
+ * Mirrors the `initialized` guard in browser-tracer.ts. Deliberately NOT reset
+ * by shutdownBrowserTracer(): the listeners survive shutdown, and re-arming
+ * them would be the very double-registration this prevents. After a re-grant
+ * the existing listeners resume emitting through the re-initialised provider.
+ */
+let capturing = false;
+
 export function captureWebVitals(): void {
     // Only run in browser
     if (typeof window === 'undefined') {
         return;
     }
+
+    if (capturing) return;
+    capturing = true;
 
     // Largest Contentful Paint - Loading performance
     // Good: < 2.5s, Needs improvement: 2.5s-4s, Poor: > 4s

--- a/apps/platform/tests/analytics/consent-premature-grant.repro.test.tsx
+++ b/apps/platform/tests/analytics/consent-premature-grant.repro.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { act } from 'react';
+import { NextIntlClientProvider } from 'next-intl';
+
+vi.mock('@next/third-parties/google', () => ({
+    GoogleTagManager: () => null,
+    sendGTMEvent: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+    useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+import { PlatformAnalytics } from '../../src/lib/infrastructure/client/analytics/platform-analytics';
+import { RuntimeConfigProvider } from '../../src/lib/infrastructure/client/context/runtime-config-context';
+import type { RuntimeConfig } from '../../src/lib/infrastructure/types/runtime-config';
+
+/**
+ * REPRODUCTION of the "premature consent grant" incident.
+ *
+ * Symptom observed live on eclass.justdoad.ch (fresh incognito, banner
+ * untouched): GA4 hits fired with `gcs=G101` (analytics_storage granted) —
+ * i.e. the app pushed a granted `consent update` BEFORE the user made any
+ * choice in the Usercentrics banner.
+ *
+ * These tests drive the real provider chain
+ *   CMP -> usercentrics adapter -> ConsentProvider -> AnalyticsProvider
+ *   -> updateConsent() -> window.gtag -> window.dataLayer
+ * and inspect what `consent update` signals land in the dataLayer.
+ *
+ * The key production fact (measured live on both justdoad.ai and
+ * eclass.justdoad.ch): the CMP reported services as consented on init, BEFORE
+ * any interaction, with `consent.type: 'IMPLICIT'`. A first-party app must not
+ * treat that pre-interaction default as a user grant.
+ *
+ * The root cause was the CMP's own per-service configuration and was fixed
+ * there. These tests pin the app's defence-in-depth layer: even if the CMP
+ * starts reporting implicit grants again, the app must not act on them.
+ */
+
+function baseConfig(): RuntimeConfig {
+    return {
+        NEXT_PUBLIC_E_CLASS_RUNTIME: 'test',
+        NEXT_PUBLIC_E_CLASS_PLATFORM_NAME: 'Test',
+        NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+        NEXT_PUBLIC_E_CLASS_CMS_REST_URL: 'http://localhost:5173',
+        defaultTheme: 'just-do-ad',
+    };
+}
+
+type DataLayerWindow = Window & {
+    dataLayer?: unknown[][];
+    gtag?: (...a: unknown[]) => void;
+    UC_UI?: unknown;
+    __ucCmp?: unknown;
+};
+
+/**
+ * Install a CMP that reports services the way production does.
+ *
+ * Production reads consent from `__ucCmp.getConsentDetails()` — the only API
+ * that reports `consent.type`, so it is the one that can tell an EXPLICIT user
+ * decision apart from an IMPLICIT pre-interaction default. (Verified live:
+ * `UC_UI.getServicesBaseInfo()` returns `{status, history}` with no `type`.)
+ */
+function installCmp(
+    services: {
+        name: string;
+        category: string;
+        given: boolean;
+        type: 'EXPLICIT' | 'IMPLICIT';
+    }[],
+): void {
+    const w = window as DataLayerWindow;
+    w.UC_UI = { isInitialized: () => true };
+    w.__ucCmp = {
+        getConsentDetails: () =>
+            Promise.resolve({
+                services: Object.fromEntries(
+                    services.map((s, i) => [
+                        `svc${i}`,
+                        {
+                            name: s.name,
+                            category: s.category,
+                            essential: false,
+                            consent: { given: s.given, type: s.type },
+                        },
+                    ]),
+                ),
+            }),
+    };
+}
+
+function installGtag(): void {
+    const w = window as DataLayerWindow;
+    w.dataLayer = [];
+    w.gtag = function (...args: unknown[]) {
+        (window as DataLayerWindow).dataLayer?.push(args);
+    };
+}
+
+function consentUpdates(): Record<string, string>[] {
+    const dl = ((window as DataLayerWindow).dataLayer ?? []) as unknown[][];
+    return dl
+        .filter((entry) => entry[0] === 'consent' && entry[1] === 'update')
+        .map((entry) => entry[2] as Record<string, string>);
+}
+
+function renderChain() {
+    return render(
+        <NextIntlClientProvider locale="en" messages={{}}>
+            <RuntimeConfigProvider
+                config={{
+                    ...baseConfig(),
+                    NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID: 'testSettingsId',
+                }}
+            >
+                <PlatformAnalytics>
+                    <span>child</span>
+                </PlatformAnalytics>
+            </RuntimeConfigProvider>
+        </NextIntlClientProvider>,
+    );
+}
+
+describe('consent premature grant (reproduction)', () => {
+    beforeEach(() => {
+        document.head.innerHTML = '';
+        installGtag();
+    });
+
+    afterEach(() => {
+        const w = window as DataLayerWindow;
+        delete w.UC_UI;
+        delete w.__ucCmp;
+        delete w.gtag;
+        delete w.dataLayer;
+    });
+
+    it('does NOT push a granted consent update on first load while the banner is untouched (implicit consent)', async () => {
+        // First-time visitor: the CMP has initialized and — as observed in
+        // production — already reports GA as consented, but the user has NOT
+        // interacted with the banner. No UC_UI_CMP_EVENT is dispatched.
+        installCmp([
+            {
+                name: 'Google Analytics',
+                category: 'marketing',
+                given: true,
+                // Implicit/default state reported before any user choice.
+                type: 'IMPLICIT',
+            },
+        ]);
+
+        renderChain();
+
+        // The CMP finishes loading and announces itself. This fires on the
+        // very first page load, before any click.
+        await act(async () => {
+            window.dispatchEvent(new Event('UC_UI_INITIALIZED'));
+            // let the async getConsentDetails promise settle
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        const grants = consentUpdates().filter(
+            (u) => u.analytics_storage === 'granted' || u.ad_storage === 'granted',
+        );
+        expect(
+            grants,
+            `Leaked a granted consent update before interaction: ${JSON.stringify(grants)}`,
+        ).toHaveLength(0);
+    });
+
+    it('DOES push a granted consent update after the user explicitly accepts', async () => {
+        // Same services, but now the user clicks "Accept All" — the CMP
+        // dispatches UC_UI_CMP_EVENT and the status is an explicit choice.
+        installCmp([
+            {
+                name: 'Google Analytics',
+                category: 'marketing',
+                given: true,
+                type: 'EXPLICIT',
+            },
+        ]);
+
+        renderChain();
+
+        await act(async () => {
+            window.dispatchEvent(new Event('UC_UI_INITIALIZED'));
+            await Promise.resolve();
+        });
+        await act(async () => {
+            // Usercentrics dispatches UC_UI_CMP_EVENT on ACCEPT_ALL.
+            window.dispatchEvent(
+                Object.assign(new Event('UC_UI_CMP_EVENT'), {
+                    detail: { type: 'ACCEPT_ALL' },
+                }),
+            );
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        const analyticsGrants = consentUpdates().filter(
+            (u) => u.analytics_storage === 'granted',
+        );
+        expect(analyticsGrants.length).toBeGreaterThan(0);
+    });
+
+    it('DOES restore a returning visitor whose stored consent is EXPLICIT on init (no interaction this session)', async () => {
+        // The risky path: a returning visitor already granted consent on a
+        // previous visit. On this load the CMP restores that decision and fires
+        // UC_UI_INITIALIZED with NO UC_UI_CMP_EVENT — but because the stored
+        // consent is EXPLICIT (a real prior choice), it must be honored.
+        installCmp([
+            {
+                name: 'Google Analytics',
+                category: 'marketing',
+                given: true,
+                type: 'EXPLICIT',
+            },
+        ]);
+
+        renderChain();
+
+        await act(async () => {
+            window.dispatchEvent(new Event('UC_UI_INITIALIZED'));
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        const analyticsGrants = consentUpdates().filter(
+            (u) => u.analytics_storage === 'granted',
+        );
+        expect(analyticsGrants.length).toBeGreaterThan(0);
+    });
+});

--- a/apps/platform/tests/analytics/noop-adapter.test.ts
+++ b/apps/platform/tests/analytics/noop-adapter.test.ts
@@ -12,11 +12,11 @@ describe('noop-adapter', () => {
         const adapter = createNoopAdapter();
         const handler = vi.fn();
         const unsubscribe = adapter.onConsentChange(handler);
-        expect(handler).toHaveBeenCalledWith({
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
             analytics: false,
             marketing: false,
             preferences: false,
-        });
+        }));
         expect(handler).toHaveBeenCalledTimes(1);
         expect(typeof unsubscribe).toBe('function');
         // Unsubscribe is a no-op but must not throw.

--- a/apps/platform/tests/analytics/otel-browser-provider.test.tsx
+++ b/apps/platform/tests/analytics/otel-browser-provider.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// vi.hoisted: vi.mock factories are hoisted above module-level consts, so the
+// spies must be created in a hoisted block to be initialised when a factory
+// runs. Referencing plain consts here silently yields a spy that never records.
+const mocks = vi.hoisted(() => ({
+    initBrowserTracer: vi.fn(),
+    shutdownBrowserTracer: vi.fn(() => Promise.resolve()),
+    captureWebVitals: vi.fn(),
+}));
+
+vi.mock(
+    '../../src/lib/infrastructure/client/telemetry/browser-tracer',
+    () => ({
+        initBrowserTracer: mocks.initBrowserTracer,
+        shutdownBrowserTracer: mocks.shutdownBrowserTracer,
+    }),
+);
+vi.mock('../../src/lib/infrastructure/client/telemetry/web-vitals', () => ({
+    captureWebVitals: mocks.captureWebVitals,
+}));
+
+const { initBrowserTracer, shutdownBrowserTracer, captureWebVitals } = mocks;
+
+/**
+ * "Telemetry started" is asserted via captureWebVitals rather than
+ * initBrowserTracer. Both are invoked on consecutive lines of the same grant
+ * branch, so either proves the branch ran, but initBrowserTracer is not
+ * observable through this mock: under Vitest's dynamic-import interop the
+ * component's destructured binding does not resolve to the spy, while
+ * captureWebVitals and shutdownBrowserTracer both do. Asserting on a spy that
+ * silently never records would make these tests vacuous.
+ */
+
+import { OTelBrowserProvider } from '../../src/lib/infrastructure/client/telemetry/OTelBrowserProvider';
+import { ConsentProvider } from '../../src/lib/infrastructure/client/analytics/consent/consent-provider';
+import type { TConsentAdapter } from '../../src/lib/infrastructure/client/analytics/consent/consent-adapter';
+import type { TConsentState } from '../../src/lib/infrastructure/client/analytics/types';
+
+/**
+ * Direct coverage for the component that turns consent into telemetry.
+ *
+ * The consent-state shape is covered in service-consent-gating.test.ts; what is
+ * tested here is the effect itself — that OTelBrowserProvider starts the tracer
+ * only when the user consented to THIS service, and shuts it down otherwise.
+ *
+ * The regression that motivated it: gating on the `analytics` category started
+ * telemetry for users who accepted Google Analytics while explicitly refusing
+ * the OpenTelemetry service.
+ */
+
+const OTEL_SERVICE = 'platform performance & error monitoring (opentelemetry)';
+
+const CONFIG = {
+    serviceName: 'test-browser',
+    otlpEndpoint: 'https://collector.example.com',
+    enabled: true,
+};
+
+/** Adapter that emits a fixed state, then lets the test push new states. */
+function controllableAdapter(initial: TConsentState) {
+    let emit: ((state: TConsentState) => void) | undefined;
+    const adapter: TConsentAdapter = {
+        init: () => undefined,
+        onConsentChange: (handler) => {
+            emit = handler;
+            handler(initial);
+            return () => {
+                emit = undefined;
+            };
+        },
+        showBanner: () => undefined,
+    };
+    return { adapter, push: (state: TConsentState) => emit?.(state) };
+}
+
+function state(overrides: Partial<TConsentState> = {}): TConsentState {
+    return {
+        analytics: false,
+        marketing: false,
+        preferences: false,
+        ...overrides,
+    };
+}
+
+function renderWith(adapter: TConsentAdapter) {
+    return render(
+        <ConsentProvider adapter={adapter}>
+            <OTelBrowserProvider config={CONFIG}>
+                <span>child</span>
+            </OTelBrowserProvider>
+        </ConsentProvider>,
+    );
+}
+
+beforeEach(() => {
+    initBrowserTracer.mockClear();
+    shutdownBrowserTracer.mockClear();
+    captureWebVitals.mockClear();
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('OTelBrowserProvider consent gating', () => {
+    it('starts telemetry when the OpenTelemetry service is consented', async () => {
+        const { adapter } = controllableAdapter(
+            state({ services: { [OTEL_SERVICE]: true } }),
+        );
+        renderWith(adapter);
+
+        // Note: a shutdown call is expected before this — the provider mounts
+        // with the all-denied default and only then receives the real state.
+        await waitFor(() => expect(captureWebVitals).toHaveBeenCalledTimes(1));
+    });
+
+    it('does NOT start telemetry when the user accepted analytics but refused the OTel service', async () => {
+        // The over-collection regression: the analytics category is granted
+        // (Google Analytics is filed under marketing and forces it true), but
+        // this specific service was refused.
+        const { adapter } = controllableAdapter(
+            state({
+                analytics: true,
+                marketing: true,
+                services: {
+                    'google analytics': true,
+                    [OTEL_SERVICE]: false,
+                },
+            }),
+        );
+        renderWith(adapter);
+
+        await waitFor(() =>
+            expect(shutdownBrowserTracer).toHaveBeenCalled(),
+        );
+        expect(captureWebVitals).not.toHaveBeenCalled();
+    });
+
+    it('starts telemetry even when no analytics category is granted, if the service itself is', async () => {
+        // The under-collection regression, mirrored.
+        const { adapter } = controllableAdapter(
+            state({ analytics: false, services: { [OTEL_SERVICE]: true } }),
+        );
+        renderWith(adapter);
+
+        await waitFor(() => expect(captureWebVitals).toHaveBeenCalledTimes(1));
+    });
+
+    it('shuts the tracer down when consent is revoked mid-session', async () => {
+        const { adapter, push } = controllableAdapter(
+            state({ services: { [OTEL_SERVICE]: true } }),
+        );
+        renderWith(adapter);
+        await waitFor(() => expect(captureWebVitals).toHaveBeenCalledTimes(1));
+
+        push(state({ services: { [OTEL_SERVICE]: false } }));
+
+        await waitFor(() => expect(shutdownBrowserTracer).toHaveBeenCalled());
+    });
+
+    it('treats an absent consent record as no consent', async () => {
+        // No services enumerated at all — must not fall back to a category.
+        const { adapter } = controllableAdapter(state({ analytics: true }));
+        renderWith(adapter);
+
+        await waitFor(() => expect(shutdownBrowserTracer).toHaveBeenCalled());
+        expect(captureWebVitals).not.toHaveBeenCalled();
+    });
+
+    it('does nothing at all when telemetry is disabled by config', async () => {
+        const { adapter } = controllableAdapter(
+            state({ services: { [OTEL_SERVICE]: true } }),
+        );
+        render(
+            <ConsentProvider adapter={adapter}>
+                <OTelBrowserProvider config={{ ...CONFIG, enabled: false }}>
+                    <span>child</span>
+                </OTelBrowserProvider>
+            </ConsentProvider>,
+        );
+
+        await Promise.resolve();
+        expect(captureWebVitals).not.toHaveBeenCalled();
+        expect(shutdownBrowserTracer).not.toHaveBeenCalled();
+    });
+});

--- a/apps/platform/tests/analytics/platform-analytics.test.tsx
+++ b/apps/platform/tests/analytics/platform-analytics.test.tsx
@@ -68,12 +68,13 @@ describe('PlatformAnalytics', () => {
                     {
                         id: 'ga',
                         categorySlug: 'statistics',
-                        consent: { status: true },
+                        // Explicit: models a user who has actively consented.
+                        consent: { status: true, type: 'EXPLICIT' },
                     },
                     {
                         id: 'ads',
                         categorySlug: 'marketing',
-                        consent: { status: true },
+                        consent: { status: true, type: 'EXPLICIT' },
                     },
                 ]),
         };

--- a/apps/platform/tests/analytics/service-consent-gating.test.ts
+++ b/apps/platform/tests/analytics/service-consent-gating.test.ts
@@ -127,6 +127,33 @@ describe('per-service consent gating', () => {
         expect(hasServiceConsent(consent, 'sentry')).toBe(false);
     });
 
+    it('does NOT grant advertising consent when the user accepted only Google Analytics', async () => {
+        // Measured on production via the CMP's granular "Save settings": a user
+        // who accepted ONLY Google Analytics had ad_storage, ad_user_data and
+        // ad_personalization granted (gcs=G111), because GA is filed under
+        // "marketing" in this tenant's dashboard and alone flipped the whole
+        // category. GA is an analytics service regardless of where the
+        // dashboard files it, so it must not imply advertising consent.
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: true },
+            { name: 'Google Ads', category: 'marketing', given: false },
+            { name: 'Facebook Pixel', category: 'marketing', given: false },
+        ]);
+
+        expect(consent.analytics).toBe(true);
+        expect(consent.marketing).toBe(false);
+    });
+
+    it('still grants marketing when a genuine marketing service is accepted', async () => {
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: true },
+            { name: 'Google Ads', category: 'marketing', given: true },
+        ]);
+
+        expect(consent.analytics).toBe(true);
+        expect(consent.marketing).toBe(true);
+    });
+
     it('still exposes per-service consent alongside the category flags', async () => {
         const consent = await readConsent([
             { name: 'Google Analytics', category: 'marketing', given: true },
@@ -140,9 +167,11 @@ describe('per-service consent gating', () => {
             [OTEL.toLowerCase()]: true,
         });
         // Category flags remain intact for Google Consent Mode, which is
-        // category-shaped by design.
+        // category-shaped by design. Marketing is false because the only
+        // granted service under it is Google Analytics, which is excluded from
+        // category aggregation — accepting GA must not grant ad consent.
         expect(consent.analytics).toBe(true);
-        expect(consent.marketing).toBe(true);
+        expect(consent.marketing).toBe(false);
         expect(consent.preferences).toBe(true);
     });
 });

--- a/apps/platform/tests/analytics/service-consent-gating.test.ts
+++ b/apps/platform/tests/analytics/service-consent-gating.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createUsercentricsAdapter } from '../../src/lib/infrastructure/client/analytics/consent/usercentrics-adapter';
+import {
+    hasServiceConsent,
+    DENIED_CONSENT,
+    type TConsentState,
+} from '../../src/lib/infrastructure/client/analytics/types';
+
+/**
+ * Per-service consent gating.
+ *
+ * The three category flags (analytics / marketing / preferences) are a lossy
+ * summary — a category is true when ANY service in it is consented. Gating one
+ * specific first-party integration on a category therefore misfires. Measured
+ * on the live CMP: Google Analytics is filed under "marketing", and our
+ * OpenTelemetry monitoring under "functional", with no statistics category at
+ * all. Gating OTel on `consent.analytics` meant a user who accepted GA but
+ * REFUSED OpenTelemetry still got telemetry sent off-device.
+ *
+ * `hasServiceConsent()` gates on the service itself instead.
+ */
+
+interface TUcCmpFixture {
+    name: string;
+    category: string;
+    given: boolean;
+}
+
+declare global {
+    interface Window {
+        __ucCmp?: unknown;
+        UC_UI?: unknown;
+    }
+}
+
+const OTEL = 'Platform Performance & Error Monitoring (OpenTelemetry)';
+
+function installCmp(services: TUcCmpFixture[]): void {
+    (window as Window).UC_UI = { isInitialized: () => true };
+    (window as Window).__ucCmp = {
+        getConsentDetails: () =>
+            Promise.resolve({
+                services: Object.fromEntries(
+                    services.map((s, i) => [
+                        `s${i}`,
+                        {
+                            name: s.name,
+                            category: s.category,
+                            essential: false,
+                            consent: { given: s.given, type: 'EXPLICIT' },
+                        },
+                    ]),
+                ),
+            }),
+    };
+}
+
+async function readConsent(services: TUcCmpFixture[]): Promise<TConsentState> {
+    installCmp(services);
+    const handler = vi.fn();
+    createUsercentricsAdapter().onConsentChange(handler);
+    await vi.waitFor(() =>
+        expect(handler.mock.calls.at(-1)?.[0]?.services).toBeDefined(),
+    );
+    return handler.mock.calls.at(-1)![0] as TConsentState;
+}
+
+afterEach(() => {
+    delete (window as Window).__ucCmp;
+    delete (window as Window).UC_UI;
+});
+
+describe('per-service consent gating', () => {
+    it('does NOT enable OTel when the user accepted Google Analytics but refused OpenTelemetry', async () => {
+        // The over-collection bug: GA lives under "marketing" and forces
+        // consent.analytics true via the GA special case, so the old
+        // category-based gate started telemetry the user had refused.
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: true },
+            { name: OTEL, category: 'functional', given: false },
+        ]);
+
+        expect(consent.analytics).toBe(true); // category flag says yes...
+        expect(hasServiceConsent(consent, 'opentelemetry')).toBe(false); // ...service says no
+    });
+
+    it('DOES enable OTel when the user accepted only the OpenTelemetry service', async () => {
+        // The under-collection case: the user consented to this service
+        // specifically, so it must run even though no analytics category is set.
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: false },
+            { name: OTEL, category: 'functional', given: true },
+        ]);
+
+        expect(consent.analytics).toBe(false);
+        expect(hasServiceConsent(consent, 'opentelemetry')).toBe(true);
+    });
+
+    it('does NOT enable OTel before any consent is given', async () => {
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: false },
+            { name: OTEL, category: 'functional', given: false },
+        ]);
+        expect(hasServiceConsent(consent, 'opentelemetry')).toBe(false);
+    });
+
+    it('treats an absent consent record as NO consent', () => {
+        // No services enumerated (noop adapter, failed read): absent is not
+        // consent — telemetry must stay off rather than fall back to a category.
+        expect(hasServiceConsent(DENIED_CONSENT, 'opentelemetry')).toBe(false);
+        expect(hasServiceConsent({ ...DENIED_CONSENT, analytics: true }, 'opentelemetry')).toBe(false);
+        // Service simply missing from an otherwise-populated payload.
+        expect(
+            hasServiceConsent(
+                { ...DENIED_CONSENT, services: { 'google analytics': true } },
+                'opentelemetry',
+            ),
+        ).toBe(false);
+    });
+
+    it('matches the service name case-insensitively on a fragment', async () => {
+        const consent = await readConsent([
+            { name: OTEL, category: 'functional', given: true },
+        ]);
+        expect(hasServiceConsent(consent, 'OpenTelemetry')).toBe(true);
+        expect(hasServiceConsent(consent, 'error monitoring')).toBe(true);
+        expect(hasServiceConsent(consent, 'sentry')).toBe(false);
+    });
+
+    it('still exposes per-service consent alongside the category flags', async () => {
+        const consent = await readConsent([
+            { name: 'Google Analytics', category: 'marketing', given: true },
+            { name: 'Sentry', category: 'functional', given: false },
+            { name: OTEL, category: 'functional', given: true },
+        ]);
+
+        expect(consent.services).toMatchObject({
+            'google analytics': true,
+            sentry: false,
+            [OTEL.toLowerCase()]: true,
+        });
+        // Category flags remain intact for Google Consent Mode, which is
+        // category-shaped by design.
+        expect(consent.analytics).toBe(true);
+        expect(consent.marketing).toBe(true);
+        expect(consent.preferences).toBe(true);
+    });
+});

--- a/apps/platform/tests/analytics/usercentrics-adapter.test.ts
+++ b/apps/platform/tests/analytics/usercentrics-adapter.test.ts
@@ -372,10 +372,13 @@ describe('usercentrics-adapter', () => {
         adapter.onConsentChange(handler);
 
         await vi.waitFor(() =>
-            // GA under "marketing" still grants analytics (the gcs=G110 fix).
+            // GA under "marketing" still grants analytics (the gcs=G110 fix),
+            // but NOT marketing: GA is an analytics service whichever category
+            // the dashboard files it under, so accepting it alone must not
+            // grant advertising consent (the gcs=G111 granular-save finding).
             expect(handler).toHaveBeenCalledWith(expect.objectContaining({
                 analytics: true,
-                marketing: true,
+                marketing: false,
                 preferences: false,
             })),
         );

--- a/apps/platform/tests/analytics/usercentrics-adapter.test.ts
+++ b/apps/platform/tests/analytics/usercentrics-adapter.test.ts
@@ -5,7 +5,7 @@ type UCService = {
     id?: string;
     name?: string;
     categorySlug?: string;
-    consent?: { status?: boolean };
+    consent?: { status?: boolean; type?: 'EXPLICIT' | 'IMPLICIT' };
 };
 
 type UC_UI = {
@@ -15,9 +15,24 @@ type UC_UI = {
     getServicesBaseInfo?: () => UCService[] | Promise<UCService[]>;
 };
 
+type UcCmp = {
+    getConsentDetails?: () => Promise<{
+        services?: Record<
+            string,
+            {
+                name?: string;
+                category?: string;
+                essential?: boolean;
+                consent?: { given?: boolean; type?: 'EXPLICIT' | 'IMPLICIT' };
+            }
+        >;
+    }>;
+};
+
 declare global {
     interface Window {
         UC_UI?: UC_UI;
+        __ucCmp?: UcCmp;
     }
 }
 
@@ -25,11 +40,13 @@ describe('usercentrics-adapter', () => {
     beforeEach(() => {
         document.head.innerHTML = '';
         delete (window as Window).UC_UI;
+        delete (window as Window).__ucCmp;
     });
 
     afterEach(() => {
         document.head.innerHTML = '';
         delete (window as Window).UC_UI;
+        delete (window as Window).__ucCmp;
     });
 
     it('init() does not inject the loader script (now rendered server-side in <head>)', () => {
@@ -42,7 +59,7 @@ describe('usercentrics-adapter', () => {
         const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
-        expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ analytics: false, marketing: false, preferences: false }));
     });
 
     it('returns denied state when UC_UI exists but isInitialized() is false', () => {
@@ -52,14 +69,14 @@ describe('usercentrics-adapter', () => {
             // anything (Promise, undefined, partial data) — the guard must
             // short-circuit BEFORE we try to iterate.
             getServicesBaseInfo: () => [
-                { id: 'x', categorySlug: 'statistics', consent: { status: true } },
+                { id: 'x', categorySlug: 'statistics', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
         const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         adapter.onConsentChange(handler);
-        expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ analytics: false, marketing: false, preferences: false }));
     });
 
     it('returns denied state when getServicesBaseInfo returns a non-array, non-thenable value', () => {
@@ -76,7 +93,7 @@ describe('usercentrics-adapter', () => {
         const adapter = createUsercentricsAdapter();
         const handler = vi.fn();
         expect(() => adapter.onConsentChange(handler)).not.toThrow();
-        expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ analytics: false, marketing: false, preferences: false }));
     });
 
     it('resolves consent state when getServicesBaseInfo returns a Promise (CMP v3.121+)', async () => {
@@ -87,8 +104,8 @@ describe('usercentrics-adapter', () => {
             isInitialized: () => true,
             getServicesBaseInfo: () =>
                 Promise.resolve([
-                    { id: 'ga', categorySlug: 'marketing', consent: { status: true } },
-                    { id: 'ot', categorySlug: 'functional', consent: { status: true } },
+                    { id: 'ga', categorySlug: 'marketing', consent: { status: true, type: 'EXPLICIT' } },
+                    { id: 'ot', categorySlug: 'functional', consent: { status: true, type: 'EXPLICIT' } },
                 ]),
         };
 
@@ -97,14 +114,14 @@ describe('usercentrics-adapter', () => {
         adapter.onConsentChange(handler);
 
         // Synchronous first call keeps the documented first-paint contract.
-        expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ analytics: false, marketing: false, preferences: false }));
 
         await vi.waitFor(() =>
-            expect(handler).toHaveBeenCalledWith({
+            expect(handler).toHaveBeenCalledWith(expect.objectContaining({
                 analytics: false,
                 marketing: true,
                 preferences: true,
-            }),
+            })),
         );
     });
 
@@ -114,7 +131,7 @@ describe('usercentrics-adapter', () => {
             isInitialized: () => true,
             getServicesBaseInfo: () =>
                 Promise.resolve([
-                    { id: 'ga', categorySlug: 'statistics', consent: { status: granted } },
+                    { id: 'ga', categorySlug: 'statistics', consent: { status: granted, type: 'EXPLICIT' } },
                 ]),
         };
 
@@ -128,18 +145,18 @@ describe('usercentrics-adapter', () => {
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
 
         await vi.waitFor(() =>
-            expect(handler).toHaveBeenCalledWith({
+            expect(handler).toHaveBeenCalledWith(expect.objectContaining({
                 analytics: true,
                 marketing: false,
                 preferences: false,
-            }),
+            })),
         );
         // The event-driven emission must not push a transient denied state.
-        expect(handler).not.toHaveBeenCalledWith({
+        expect(handler).not.toHaveBeenCalledWith(expect.objectContaining({
             analytics: false,
             marketing: false,
             preferences: false,
-        });
+        }));
     });
 
     it('drops stale async resolutions so an older snapshot cannot overwrite a newer one', async () => {
@@ -149,7 +166,7 @@ describe('usercentrics-adapter', () => {
         let resolveFirst: (s: UCService[]) => void = () => undefined;
         const first = new Promise<UCService[]>((res) => { resolveFirst = res; });
         const second = Promise.resolve([
-            { id: 'ga', categorySlug: 'statistics', consent: { status: true } },
+            { id: 'ga', categorySlug: 'statistics', consent: { status: true, type: 'EXPLICIT' } },
         ]);
         let call = 0;
         window.UC_UI = {
@@ -164,11 +181,11 @@ describe('usercentrics-adapter', () => {
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
         await vi.waitFor(() =>
-            expect(handler).toHaveBeenCalledWith({
+            expect(handler).toHaveBeenCalledWith(expect.objectContaining({
                 analytics: true,
                 marketing: false,
                 preferences: false,
-            }),
+            })),
         );
         handler.mockClear();
 
@@ -206,7 +223,7 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         unsubscribe();
-        resolveServices([{ id: 'ga', categorySlug: 'statistics', consent: { status: true } }]);
+        resolveServices([{ id: 'ga', categorySlug: 'statistics', consent: { status: true, type: 'EXPLICIT' } }]);
         await new Promise((res) => setTimeout(res, 10));
         expect(handler).not.toHaveBeenCalled();
     });
@@ -215,9 +232,9 @@ describe('usercentrics-adapter', () => {
         window.UC_UI = {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
-                { id: 'ga', name: 'Google Analytics', categorySlug: 'statistics', consent: { status: true } },
+                { id: 'ga', name: 'Google Analytics', categorySlug: 'statistics', consent: { status: true, type: 'EXPLICIT' } },
                 { id: 'meta', name: 'Meta Pixel', categorySlug: 'marketing', consent: { status: false } },
-                { id: 'ytp', name: 'YouTube preferences', categorySlug: 'functional', consent: { status: true } },
+                { id: 'ytp', name: 'YouTube preferences', categorySlug: 'functional', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
@@ -227,11 +244,11 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
-        expect(handler).toHaveBeenCalledWith({
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
             analytics: true,
             marketing: false,
             preferences: true,
-        });
+        }));
     });
 
     it('grants analytics when the Google Analytics service is consented, even under a "marketing" category', () => {
@@ -243,8 +260,8 @@ describe('usercentrics-adapter', () => {
         window.UC_UI = {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
-                { id: 'ga', name: 'Google Analytics', categorySlug: 'marketing', consent: { status: true } },
-                { id: 'gtm', name: 'Google Tag Manager', categorySlug: 'marketing', consent: { status: true } },
+                { id: 'ga', name: 'Google Analytics', categorySlug: 'marketing', consent: { status: true, type: 'EXPLICIT' } },
+                { id: 'gtm', name: 'Google Tag Manager', categorySlug: 'marketing', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
@@ -254,11 +271,11 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
-        expect(handler).toHaveBeenCalledWith({
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
             analytics: true,
             marketing: true,
             preferences: false,
-        });
+        }));
     });
 
     it('does NOT grant analytics from other marketing services when Google Analytics itself is refused', () => {
@@ -266,7 +283,7 @@ describe('usercentrics-adapter', () => {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
                 { id: 'ga', name: 'Google Analytics', categorySlug: 'marketing', consent: { status: false } },
-                { id: 'li', name: 'LinkedIn Insight Tag', categorySlug: 'marketing', consent: { status: true } },
+                { id: 'li', name: 'LinkedIn Insight Tag', categorySlug: 'marketing', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
@@ -276,19 +293,19 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
-        expect(handler).toHaveBeenCalledWith({
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
             analytics: false,
             marketing: true,
             preferences: false,
-        });
+        }));
     });
 
     it('treats "analytics" and "preferences" slugs as equivalent aliases', () => {
         window.UC_UI = {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
-                { id: 'x', categorySlug: 'analytics', consent: { status: true } },
-                { id: 'y', categorySlug: 'preferences', consent: { status: true } },
+                { id: 'x', categorySlug: 'analytics', consent: { status: true, type: 'EXPLICIT' } },
+                { id: 'y', categorySlug: 'preferences', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
@@ -298,18 +315,133 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
-        expect(handler).toHaveBeenCalledWith({
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
             analytics: true,
             marketing: false,
             preferences: true,
-        });
+        }));
+    });
+
+    // ---- Preferred source: __ucCmp.getConsentDetails() -------------------
+    // Only this API reports `consent.type`, so it is the only place the
+    // EXPLICIT/IMPLICIT distinction can be enforced. Verified live (2026-08):
+    // getServicesBaseInfo() returns {status, history} with no type.
+
+    it('prefers __ucCmp.getConsentDetails() and does NOT grant on IMPLICIT consent', async () => {
+        // First load, banner untouched: the CMP reports services as consented
+        // but flagged IMPLICIT. That is a pre-interaction default, not a user
+        // decision — acting on it is the premature-grant bug (gcs=G101).
+        window.__ucCmp = {
+            getConsentDetails: () =>
+                Promise.resolve({
+                    services: {
+                        a: { name: 'Google Analytics', category: 'statistics', consent: { given: true, type: 'IMPLICIT' } },
+                        b: { name: 'Meta Pixel', category: 'marketing', consent: { given: true, type: 'IMPLICIT' } },
+                        c: { name: 'YouTube', category: 'functional', consent: { given: true, type: 'IMPLICIT' } },
+                    },
+                }),
+        };
+        window.UC_UI = { isInitialized: () => true };
+
+        const adapter = createUsercentricsAdapter();
+        const handler = vi.fn();
+        adapter.onConsentChange(handler);
+
+        await new Promise((res) => setTimeout(res, 10));
+        expect(handler).not.toHaveBeenCalledWith(
+            expect.objectContaining({ analytics: true }),
+        );
+        expect(handler).not.toHaveBeenCalledWith(
+            expect.objectContaining({ marketing: true }),
+        );
+    });
+
+    it('grants from __ucCmp when consent is EXPLICIT', async () => {
+        window.__ucCmp = {
+            getConsentDetails: () =>
+                Promise.resolve({
+                    services: {
+                        a: { name: 'Google Analytics', category: 'marketing', consent: { given: true, type: 'EXPLICIT' } },
+                    },
+                }),
+        };
+        window.UC_UI = { isInitialized: () => true };
+
+        const adapter = createUsercentricsAdapter();
+        const handler = vi.fn();
+        adapter.onConsentChange(handler);
+
+        await vi.waitFor(() =>
+            // GA under "marketing" still grants analytics (the gcs=G110 fix).
+            expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+                analytics: true,
+                marketing: true,
+                preferences: false,
+            })),
+        );
+    });
+
+    it('ignores a mix of IMPLICIT grants while honouring the EXPLICIT ones', async () => {
+        window.__ucCmp = {
+            getConsentDetails: () =>
+                Promise.resolve({
+                    services: {
+                        a: { name: 'Google Analytics', category: 'statistics', consent: { given: true, type: 'EXPLICIT' } },
+                        b: { name: 'Meta Pixel', category: 'marketing', consent: { given: true, type: 'IMPLICIT' } },
+                    },
+                }),
+        };
+        window.UC_UI = { isInitialized: () => true };
+
+        const adapter = createUsercentricsAdapter();
+        const handler = vi.fn();
+        adapter.onConsentChange(handler);
+
+        await vi.waitFor(() =>
+            expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+                analytics: true,
+                marketing: false, // IMPLICIT — must not be treated as consent
+                preferences: false,
+            })),
+        );
+    });
+
+    // ---- Fallback source: getServicesBaseInfo() ---------------------------
+
+    it('falls back to getServicesBaseInfo when __ucCmp is unavailable, and warns', () => {
+        // getServicesBaseInfo cannot report explicitness, so this path
+        // deliberately fails OPEN and trusts `status` — failing closed would
+        // permanently deny consent even for users who accepted, silently
+        // killing analytics (the gcs=G100 incident). The degraded protection
+        // is surfaced via console.warn so it is observable.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        window.UC_UI = {
+            isInitialized: () => true,
+            getServicesBaseInfo: () => [
+                { id: 'ga', name: 'Google Analytics', categorySlug: 'statistics', consent: { status: true } },
+            ],
+        };
+
+        const adapter = createUsercentricsAdapter();
+        const handler = vi.fn();
+        adapter.onConsentChange(handler);
+
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+            analytics: true,
+            marketing: false,
+            preferences: false,
+        }));
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('__ucCmp'),
+        );
+        warn.mockRestore();
     });
 
     it('ignores unknown category slugs (safe default)', () => {
         window.UC_UI = {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
-                { id: 'x', categorySlug: 'something-weird', consent: { status: true } },
+                { id: 'x', categorySlug: 'something-weird', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 
@@ -319,14 +451,14 @@ describe('usercentrics-adapter', () => {
         handler.mockClear();
 
         window.dispatchEvent(new Event('UC_UI_CMP_EVENT'));
-        expect(handler).toHaveBeenCalledWith({ analytics: false, marketing: false, preferences: false });
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ analytics: false, marketing: false, preferences: false }));
     });
 
     it('unsubscribe stops further callbacks', () => {
         window.UC_UI = {
             isInitialized: () => true,
             getServicesBaseInfo: () => [
-                { id: 'x', categorySlug: 'statistics', consent: { status: true } },
+                { id: 'x', categorySlug: 'statistics', consent: { status: true, type: 'EXPLICIT' } },
             ],
         };
 


### PR DESCRIPTION
## Summary

Investigates the "premature consent grant" incident from scratch, reproduces it locally and live, and fixes it.

**The root cause was not in this repo.** It was per-service configuration in Usercentrics, which pre-granted 7 non-essential services as `type: IMPLICIT` before any user interaction. That has been fixed in the dashboard and verified live — **both production sites now pass**.

What remains here is (a) a live audit suite that proves it, with committed before/after evidence, and (b) app-side defence-in-depth so a future dashboard regression cannot silently re-leak.

## Root cause

Measured live from a Swiss IP, banner untouched, fresh browser profile:

| Site | Before fix | After fix |
| --- | --- | --- |
| justdoad.ai (Wix) | `G100` → **`G101`** | **`G100`** only ✅ |
| eclass.justdoad.ch (Next.js) | `G100` → **`G101`** → **`G111`** | **`G100`** only ✅ |

Both sites load the **same** Usercentrics config (`jnaPMX-WDaJ4Ig`) and pre-granted the same 7 services: Google Analytics, Google Ads, Google Tag Manager, DoubleClick Ad, LinkedIn Insight Tag, LinkedIn Plugin, YouTube Video.

Attribution, from the dataLayer payload shapes:
- the shared **`G101`** came from the **Usercentrics GTM template** acting on implicit consent
- the extra **`G111`** on eclass came from the **app's own consent bridge** escalating it to ad consent

After an explicit Accept: `ALL_ACCEPTED`, GA consent `type=EXPLICIT`, `gcs=G111` — consent works in both directions.

## Correcting the original diagnosis

The reported diagnosis was that justdoad.ai was clean, localising the defect to the Next.js integration. **Measurement disproves this**: the Wix site — which has no app-side consent bridge at all — leaks `G101` from the same shared config. The app made it *worse* on eclass, but was not the cause. `apps/platform-e2e/src/consent-audit.spec.ts` encodes this so it can't be re-litigated from memory.

## What's in this PR

**1. Live audit suite** — `apps/platform-e2e/src/consent-audit.spec.ts` (own config, no `webServer`, deliberately **out of CI** since it depends on live third-party infra):
```
pnpm exec playwright test -c apps/platform-e2e/consent-audit.config.ts
```
Asserts, before any interaction: no non-essential service consented, no granted `gtag` consent update, every GA4 hit at `gcs=G100`; and after a real banner click: consent recorded `EXPLICIT` and GA4 actually granted. Committed before/after evidence in `consent-audit-results/`.

**2. Adapter defence-in-depth** — reads `consent.type` from `window.__ucCmp.getConsentDetails()` and grants only on `EXPLICIT`. Note `UC_UI.getServicesBaseInfo()` does *not* carry a `type` field (verified live: `{status, history}`), so gating on it there would deny consent permanently. Preserves both prior incident fixes: the async/Promise staleness ticket (`G100`) and the GA-under-`marketing` special case (`G110`).

**3. Per-service telemetry gating** — `OTelBrowserProvider` gated on `consent.analytics`, assuming the CMP filed it under Statistics/Analytics. It doesn't: the service is under `functional`, and there is no statistics category. Both directions misfired, neither visible on Accept-All/Deny-All:
- **over-collection**: accepted GA + *refused* OpenTelemetry → telemetry ran anyway (GA is under `marketing` and forces `analytics: true`). Browser traces send IP/URL/page.route off-device (ePrivacy Art. 5(3)).
- **under-collection**: accepted *only* OpenTelemetry → nothing ran.

Now gates on the service itself via `hasServiceConsent()`. No Usercentrics change needed — the service already exists (`VV9OqJHc7FtzIJ`).

## Deliberate design decisions

- **Adapter fallback fails OPEN.** Without `__ucCmp`, it trusts `status` as before and emits a `console.warn`. Failing closed on a source that cannot answer the question would deny consent even for users who accepted, silently killing analytics. The CMP config is the primary control; this is a second layer.
- **Telemetry gating fails CLOSED.** An absent consent record means telemetry stays off. Opposite choice, deliberately: this is one non-critical service transmitting personal data off-device, so the safe direction is off. Trade-off: if the service were deleted from the dashboard, monitoring would stop silently.
- **Bot evasion in the audit is load-bearing.** Usercentrics serves a permissive config to headless automation (`isBot=true`) under which everything reports accepted. The suite spoofs a normal fingerprint and asserts the bot config was *not* served, so a broken evasion fails loudly instead of reporting a false all-clear.

## Not covered

- The audit exercises Accept-All and Deny-All only; **granular "Save settings" is untested**, which is exactly why the OTel category mismatch went unnoticed. Worth adding.
- **Sentry** is also under `functional` and may have the same category-proxy issue — not investigated.
- Google Tag Manager is among the 7 pre-granted services; blocking the container itself can suppress Consent Mode signals entirely. It currently still loads (`page_view` fires at `G100`), but confirm that was deliberate.

## Related

The CI fix for the failing `claude-review` workflow (retired default model) is split out into #704 so it isn't gated behind this review.
