### PR TITLE
Fix course page access for admin/coach roles, groups visibility, assessment preview dividers

### DIFF
--- a/apps/platform/src/lib/infrastructure/client/pages/course/enrolled-course/coach-course-groups.tsx
+++ b/apps/platform/src/lib/infrastructure/client/pages/course/enrolled-course/coach-course-groups.tsx
@@ -280,6 +280,7 @@ export default function CoachCourseGroups({
                 validationMessage={feedbackMessage?.message}
                 validationMessageType={feedbackMessage?.type}
                 isLoading={registerCoachMutation.isPending}
+                showGroupToggle={currentRole !== 'coach'}
             />
 
             {/* Load More Button */}

--- a/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
@@ -110,10 +110,9 @@ export default async function CourseServerComponent({
         return renderVisitorView(slug, locale);
     }
 
-    let rawRole = role ?? highestRoleParsed;
+    let rawRole = (role ?? highestRoleParsed) as (typeof roles)[number];
     if (!roles.includes(rawRole)) {
-        const privileged = ['admin', 'superadmin'];
-        const userPrivilegedRole = roles.find((r: string) => privileged.includes(r));
+        const userPrivilegedRole = roles.find((r) => r === 'admin' || r === 'superadmin');
         if (userPrivilegedRole) {
             rawRole = userPrivilegedRole;
         }

--- a/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
+++ b/apps/platform/src/lib/infrastructure/server/pages/course-rsc.tsx
@@ -110,7 +110,14 @@ export default async function CourseServerComponent({
         return renderVisitorView(slug, locale);
     }
 
-    const rawRole = role ?? highestRoleParsed;
+    let rawRole = role ?? highestRoleParsed;
+    if (!roles.includes(rawRole)) {
+        const privileged = ['admin', 'superadmin'];
+        const userPrivilegedRole = roles.find((r: string) => privileged.includes(r));
+        if (userPrivilegedRole) {
+            rawRole = userPrivilegedRole;
+        }
+    }
     validateRoleAccess(rawRole, roles);
     // Normalize superadmin→admin for all downstream components (same privileges in UI)
     const currentRole = rawRole === 'superadmin' ? 'admin' : rawRole;

--- a/package.json
+++ b/package.json
@@ -134,6 +134,5 @@
         "vite-plugin-checker": "^0.11.0",
         "vite-plugin-dts": "4.5.4",
         "vitest": "^3.2.1"
-    },
-    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -134,5 +134,6 @@
         "vite-plugin-checker": "^0.11.0",
         "vite-plugin-dts": "4.5.4",
         "vitest": "^3.2.1"
-    }
+    },
+    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
 }

--- a/packages/translations/src/lib/dictionaries/de.ts
+++ b/packages/translations/src/lib/dictionaries/de.ts
@@ -1284,7 +1284,7 @@ export const DE: TDictionary = {
       defaultSortBy: 'Titel',
     },
     assignmentOverviewList: {
-      emptyState: 'Noch keine Aufgaben eingereicht.',
+      emptyState: 'Keine Aufgaben zur Prüfung eingereicht.',
     },
     userAvatarReel: {
       andLabel: 'und',

--- a/packages/translations/src/lib/dictionaries/en.ts
+++ b/packages/translations/src/lib/dictionaries/en.ts
@@ -1281,7 +1281,7 @@ export const EN: TDictionary = {
       defaultSortBy: 'title',
     },
     assignmentOverviewList: {
-      emptyState: 'No assignments yet.',
+      emptyState: 'No assignments pending review.',
     },
     userAvatarReel: {
       andLabel: 'and',

--- a/packages/ui-kit/lib/components/groups-card/groups-list.tsx
+++ b/packages/ui-kit/lib/components/groups-card/groups-list.tsx
@@ -33,6 +33,9 @@ export interface GroupsListProps {
   
   // Loading states
   isLoading?: boolean;
+
+  // Whether to show the "All Groups / Your Groups" toggle (hidden for coaches, shown for admins)
+  showGroupToggle?: boolean;
 }
 
 /**
@@ -74,6 +77,7 @@ export const GroupsList: FC<GroupsListProps> = ({
   onClickManage,
   onClickViewProfile,
   isLoading = false,
+  showGroupToggle = true,
 }) => {
   const dictionary = getDictionary(locale);
   const [activeTab, setActiveTab] = useState('all-groups');
@@ -103,33 +107,35 @@ export const GroupsList: FC<GroupsListProps> = ({
         <div className="flex items-center justify-between">
           <h2 className="text-white text-3xl font-bold leading-[100%] tracking-[-0.64px]">{dictionary.components.groupsList.title}</h2>
           
-          {/* Tab Navigation - compact width */}
-          <Tabs.List className="flex gap-1 border border-card-stroke rounded-md p-1 w-auto">
-            <Tabs.Trigger 
-              value="all-groups"
-              isLast={false}
-              className={cn(
-                'px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
-                activeTab === 'all-groups' 
-                  ? 'bg-button-primary-fill text-button-primary-text' 
-                  : 'text-text-secondary hover:text-text-primary'
-              )}
-            >
-              {dictionary.components.groupsList.allGroups}
-            </Tabs.Trigger>
-            <Tabs.Trigger 
-              value="your-groups"
-              isLast={true}
-              className={cn(
-                'px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
-                activeTab === 'your-groups' 
-                  ? 'bg-button-primary-fill text-button-primary-text' 
-                  : 'text-text-secondary hover:text-text-primary'
-              )}
-            >
-              {dictionary.components.groupsList.yourGroups}
-            </Tabs.Trigger>
-          </Tabs.List>
+          {/* Tab Navigation - compact width, hidden for coaches */}
+          {showGroupToggle && (
+            <Tabs.List className="flex gap-1 border border-card-stroke rounded-md p-1 w-auto">
+              <Tabs.Trigger
+                value="all-groups"
+                isLast={false}
+                className={cn(
+                  'px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
+                  activeTab === 'all-groups'
+                    ? 'bg-button-primary-fill text-button-primary-text'
+                    : 'text-text-secondary hover:text-text-primary'
+                )}
+              >
+                {dictionary.components.groupsList.allGroups}
+              </Tabs.Trigger>
+              <Tabs.Trigger
+                value="your-groups"
+                isLast={true}
+                className={cn(
+                  'px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
+                  activeTab === 'your-groups'
+                    ? 'bg-button-primary-fill text-button-primary-text'
+                    : 'text-text-secondary hover:text-text-primary'
+                )}
+              >
+                {dictionary.components.groupsList.yourGroups}
+              </Tabs.Trigger>
+            </Tabs.List>
+          )}
         </div>
 
         {/* Tab Content */}

--- a/packages/ui-kit/lib/components/pre-assessment/pre-course-assessment-previewer.tsx
+++ b/packages/ui-kit/lib/components/pre-assessment/pre-course-assessment-previewer.tsx
@@ -10,7 +10,6 @@ import { FormComponent as SingleChoiceFormComponent } from '../lesson-components
 import { FormComponent as MultiCheckFormComponent } from '../lesson-components/multi-check';
 import { FormComponent as OneOutOfThreeFormComponent } from '../lesson-components/one-out-of-three';
 import { FormComponent as UploadFilesFormComponent } from '../lesson-components/upload-files';
-import { Divider } from '../divider';
 import { isLocalAware } from '@maany_shr/e-class-translations';
 import { fileMetadata } from '@maany_shr/e-class-models';
 
@@ -129,12 +128,9 @@ export function PreCourseAssessmentPreviewer({
 
     return (
         <div className="flex flex-col gap-5">
-            {components.map((component, index) => (
+            {components.map((component) => (
                 <div key={component.id}>
                     {renderComponent(component)}
-                    {index < components.length - 1 && (
-                        <Divider className="mb-5 mt-5" />
-                    )}
                 </div>
             ))}
         </div>


### PR DESCRIPTION
## Summary

- Allow admin/superadmin users to view course pages when URL contains `?role=coach`
- Hide groups toggle for coaches now that the backend filters by role
- Remove unnecessary dividers between pre-course assessment form components in CMS preview
- Fix translation typos

## Changes

- Update `course-rsc.tsx` to handle admin/superadmin access with `?role=coach` param
- Update `groups-list.tsx` to hide toggle when user is a coach (backend handles filtering)
- Clean up divider rendering in `pre-course-assessment-previewer.tsx`
- Fix translation strings in `en.ts` / `de.ts`