### PR TITLE
ci: pin Claude model — the action's default was retired

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,13 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. The action's built-in default was
+          # claude-sonnet-4-20250514, which has since been retired — leaving
+          # this unset made every run fail with:
+          #   API Error: 404 not_found_error: model: claude-sonnet-4-20250514
+          # Use claude-opus-5 for deeper review, or claude-haiku-4-5-20251001
+          # for a cheaper/faster pass.
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,13 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. The action's built-in default was
+          # claude-sonnet-4-20250514, which has since been retired — leaving
+          # this unset made every run fail with:
+          #   API Error: 404 not_found_error: model: claude-sonnet-4-20250514
+          # Use claude-opus-5 for harder tasks, or claude-haiku-4-5-20251001
+          # for a cheaper/faster pass.
+          model: "claude-sonnet-5"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Problem

The `claude-review` workflow has been failing on **every** PR in this repo, dying in ~3 seconds having consumed zero tokens:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error",
"message":"model: claude-sonnet-4-20250514"}}
```

The `model:` input was left commented out, so the action fell back to its built-in default of `claude-sonnet-4-20250514` — a model that has since been retired. The request 404s before any review work starts, which is why the failure is fast and free.

## Fix

Pins the model explicitly:

- `.github/workflows/claude-code-review.yml` — the workflow that was visibly failing
- `.github/workflows/claude.yml` — same latent bug, just triggered less often (`@claude` mentions)

Both now use `claude-sonnet-5`. The comment records that the previous default was retired, so the next retirement is quicker to diagnose. Swap to `claude-opus-5` for deeper review or `claude-haiku-4-5-20251001` for a cheaper pass.

## Expected: this PR's own `claude-review` check will fail

The action refuses to mint a token when the workflow file differs from the version on the default branch:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

That is a deliberate guard — otherwise any PR could rewrite CI to reach repository secrets. It means **no PR that edits this workflow can make the check pass**, including this one. The action's own error text calls this out as expected behaviour.

Verified the underlying fix works: the run after pinning resolves `model: claude-sonnet-5` with no 404, and now fails only at the workflow-validation step described above.

Once this is on `main`, `claude-review` works for all PRs.

## Scope

Two comment/config lines in two workflow files. No application code. Split out of #702 so the repo-wide CI fix isn't gated behind that review.
