### PR TITLE
test(platform-e2e): record post-deploy consent audit evidence

### DIFF
--- a/apps/platform-e2e/consent-audit-results/consent-audit-after-bridge-removal.json
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-after-bridge-removal.json
@@ -1,0 +1,352 @@
+{
+  "label": "after-bridge-removal",
+  "takenAt": "2026-08-03T20:36:59.669Z",
+  "sites": [
+    {
+      "site": "justdoad.ai (Wix)",
+      "url": "https://www.justdoad.ai/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "ALL_DENIED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          }
+        ]
+      }
+    },
+    {
+      "site": "eclass.justdoad.ch (Next.js)",
+      "url": "https://eclass.justdoad.ch/",
+      "observed": {
+        "settingsId": "jnaPMX-WDaJ4Ig",
+        "consentRequired": true,
+        "overallStatus": "ALL_DENIED",
+        "services": [
+          {
+            "name": "Auth0",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Syndication",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "gstatic.com",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Mux",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Stripe",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Usercentrics Consent Management Platform",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "WIX",
+            "category": "essential",
+            "essential": true,
+            "given": true,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Conversion Linker",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "DoubleClick Ad",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Pixel",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Facebook Social Plugins",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Ads",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Analytics",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Fonts",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Google Tag Manager",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Insight Tag",
+            "category": "marketing",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "LinkedIn Plugin",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Platform Performance & Error Monitoring (OpenTelemetry)",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "reCAPTCHA",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "Sentry",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "TikTok",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          },
+          {
+            "name": "YouTube Video",
+            "category": "functional",
+            "essential": false,
+            "given": false,
+            "type": "IMPLICIT"
+          }
+        ],
+        "updates": [],
+        "isBotConfig": false,
+        "gaHits": [
+          {
+            "gcs": "G100",
+            "event": "page_view"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/platform-e2e/consent-audit-results/consent-audit-after-bridge-removal.md
+++ b/apps/platform-e2e/consent-audit-results/consent-audit-after-bridge-removal.md
@@ -1,0 +1,55 @@
+# Consent Mode audit — `after-bridge-removal`
+
+Taken: 2026-08-03T20:36:59.669Z
+
+A first-time visitor who has NOT touched the cookie banner must have no
+tracking consent: no non-essential service granted, no granted `gtag`
+consent update, and every GA4 hit at `gcs=G100`.
+
+## justdoad.ai (Wix)
+
+- URL: https://www.justdoad.ai/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `ALL_DENIED`
+- **verdict: PASS ✅**
+
+### Non-essential services granted before any click (0)
+
+_None — correct._
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| page_view | ✅ G100 (both denied — correct before consent) |
+
+### Granted consent updates pushed pre-click (0)
+
+_None — correct._
+
+## eclass.justdoad.ch (Next.js)
+
+- URL: https://eclass.justdoad.ch/
+- Usercentrics settings id: `jnaPMX-WDaJ4Ig`
+- consent required: `true`
+- overall status: `ALL_DENIED`
+- **verdict: PASS ✅**
+
+### Non-essential services granted before any click (0)
+
+_None — correct._
+
+### GA4 hits
+
+| Event | Consent Mode signal |
+| --- | --- |
+| page_view | ✅ G100 (both denied — correct before consent) |
+
+### Granted consent updates pushed pre-click (0)
+
+_None — correct._
+
+## Shared configuration
+
+Both sites load the same Usercentrics configuration `jnaPMX-WDaJ4Ig`, so one dashboard change affects both.


### PR DESCRIPTION
Evidence-only. No source changes — two artifact files.

#706 was merged and deployed before the live audit could run against it (that audit necessarily needs deployed code). This records the post-deploy run so the before/after evidence stays complete and diffable alongside `before-fix` and `after-fix`.

**All 7 checks pass on both production sites.** The two that verify #705 specifically:

**Single writer** — Accept All on eclass produced exactly **one** consent update:

```json
{"ad_storage":"granted","ad_personalization":"granted","ad_user_data":"granted","analytics_storage":"granted"}
```

Four keys, no `personalization_storage` — the fingerprint of an app-side write. There were two writers before.

**Granular save** — accepting only Google Analytics now produces one update with `analytics_storage: granted` and **every advertising signal denied**, plus zero OpenTelemetry collector posts. This is the exact case that reported `gcs=G111` and leaked telemetry for a refused service.

Both sites remain at `ALL_DENIED` / `gcs=G100` before the banner is touched, and both still share configuration `jnaPMX-WDaJ4Ig`.

Acceptance criteria from #705 are all met:

- [x] nothing granted before interaction (`gcs=G100`)
- [x] correct grants after Accept
- [x] granular save grants nothing beyond the accepted service
- [x] exactly one `consent update` payload rather than two
- [x] OpenTelemetry starts only when its own service is consented

The Usercentrics category cleanup (TikTok → `marketing`, create `statistics`) is still outstanding and unaffected by this — it is a user-transparency improvement, not a correctness one.
